### PR TITLE
Fix bugs and simplify dataset pipeline

### DIFF
--- a/src/miao/axes.py
+++ b/src/miao/axes.py
@@ -39,6 +39,14 @@ def compute_permutation(input_axes: str, output_axes: str) -> tuple[int, ...]:
     return tuple(input_index[char] for char in output_axes)
 
 
+def invert_permutation(perm: tuple[int, ...] | list[int]) -> list[int]:
+    """Return the inverse permutation: inv[perm[i]] == i for all i."""
+    inv = [0] * len(perm)
+    for i, p in enumerate(perm):
+        inv[p] = i
+    return inv
+
+
 def reorient(array: np.ndarray, input_axes: str, output_axes: str) -> np.ndarray:
     """Transpose array from input axis order to output axis order."""
     if input_axes == output_axes:
@@ -59,6 +67,6 @@ def map_patch_size_to_input(
     """
     if input_axes == output_axes:
         return list(patch_size)
-    # Inverse permutation: for each position in input, find where it ends up in output
     perm = compute_permutation(output_axes, input_axes)
-    return [patch_size[perm.index(i)] for i in range(len(patch_size))]
+    inv = invert_permutation(perm)
+    return [patch_size[i] for i in inv]

--- a/src/miao/config.py
+++ b/src/miao/config.py
@@ -29,6 +29,24 @@ class VolumeConfig(BaseModel):
             raise ValueError(f"weight must be positive, got {v}")
         return v
 
+    @field_validator("bounding_box")
+    @classmethod
+    def validate_bounding_box(
+        cls, v: Optional[list[list[int]]]
+    ) -> Optional[list[list[int]]]:
+        if v is None:
+            return v
+        for i, pair in enumerate(v):
+            if len(pair) != 2:
+                raise ValueError(
+                    f"bounding_box axis {i} must be [min, max]; got {pair}"
+                )
+            if pair[0] > pair[1]:
+                raise ValueError(
+                    f"bounding_box axis {i}: min ({pair[0]}) > max ({pair[1]})"
+                )
+        return v
+
 
 class MiaoConfig(BaseModel):
     """Top-level configuration for miaio dataset."""

--- a/src/miao/dataset.py
+++ b/src/miao/dataset.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import warnings
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -13,14 +14,14 @@ import torch.utils.data
 
 from miao.axes import (
     compute_permutation,
+    invert_permutation,
     map_patch_size_to_input,
-    reorient,
     spatial_axes,
     spatial_indices,
 )
 from miao.config import MiaoConfig, VolumeConfig
 from miao.store import create_context, open_store
-from miao.zarr_meta import OmeMetadata, ScaleMetadata, read_ome_metadata
+from miao.zarr_meta import OmeMetadata, read_ome_metadata
 
 
 @dataclass
@@ -64,7 +65,8 @@ class VolumeDataset(torch.utils.data.Dataset):
     3. Extracts patch_size voxels from each requested scale level.
     4. Returns {"img": Tensor, "label": Tensor | None, "bbox": Tensor, "meta": dict}.
 
-    Tensor shapes are (1, L, *output_axes_dims) where L = number of scale levels.
+    Tensor shape follows config.output_axes (which must contain 'l' for the scale-level dim).
+    A DataLoader adds the leading batch dim, so iterating a DataLoader yields (B, *output_axes_dims).
     Input axes are auto-detected from OME-NGFF metadata.
     """
 
@@ -91,10 +93,10 @@ class VolumeDataset(torch.utils.data.Dataset):
         print(f"VolumeDataset: {len(self._volumes)} volume(s), "
               f"{self.config.samples_per_epoch} samples/epoch, "
               f"patch_size={self.config.patch_size}")
-        for vi in self._volumes:
+        for i, vi in enumerate(self._volumes):
             finest = min(vi.config.scales)
             finest_meta = vi.image_meta.scales[finest]
-            prob = self._probabilities[self._volumes.index(vi)]
+            prob = self._probabilities[i]
             # Get axis unit from OME-NGFF metadata
             units = [ax.get("unit", "") for ax in vi.image_meta.axes]
             unit_str = units[0] if units and all(u == units[0] for u in units if u) else ""
@@ -166,6 +168,15 @@ class VolumeDataset(torch.utils.data.Dataset):
         )
         finest_spatial_factors = finest_all_factors[img_sp_idx]
 
+        image_dtype = image_meta.scales[finest_scale].dtype
+        if vol_cfg.normalize and not np.issubdtype(image_dtype, np.integer):
+            warnings.warn(
+                f"Volume {vol_cfg.name!r}: normalize=True but image dtype is "
+                f"{image_dtype} (non-integer). Normalization is a no-op for "
+                f"non-integer dtypes; set normalize=False to silence this warning.",
+                stacklevel=2,
+            )
+
         relative_scale_factors: dict[int, np.ndarray] = {}
         for level in vol_cfg.scales:
             level_all = np.array(
@@ -176,6 +187,20 @@ class VolumeDataset(torch.utils.data.Dataset):
         # Compute label spatial-only relative scale factors
         label_relative_scale_factors: dict[int, np.ndarray] | None = None
         if label_meta is not None and lbl_sp_idx is not None:
+            # Labels must share the image's finest-scale physical voxel size,
+            # since `center` is sampled in image-finest coordinates and divided
+            # by label scale factors to locate label patches.
+            lbl_finest_all = np.array(
+                label_meta.scales[finest_scale].scale_factors, dtype=np.float64
+            )
+            lbl_finest_spatial = lbl_finest_all[lbl_sp_idx]
+            if not np.allclose(lbl_finest_spatial, finest_spatial_factors):
+                raise ValueError(
+                    f"Volume {vol_cfg.name!r}: label finest-scale voxel size "
+                    f"{lbl_finest_spatial.tolist()} does not match image finest-scale "
+                    f"voxel size {finest_spatial_factors.tolist()}. "
+                    f"Image and label pyramids must share the same finest-scale physical resolution."
+                )
             label_relative_scale_factors = {}
             for level in vol_cfg.scales:
                 lbl_all = np.array(
@@ -201,7 +226,6 @@ class VolumeDataset(torch.utils.data.Dataset):
         finest_all_shape = np.array(image_meta.scales[finest_scale].shape)
         finest_spatial_shape = finest_all_shape[img_sp_idx]
         read_shape_arr = np.array(read_shape, dtype=np.float64)
-        half_patch = np.floor(read_shape_arr / 2)
 
         min_center = np.zeros(len(img_sp_idx), dtype=np.float64)
         max_center = finest_spatial_shape.copy().astype(np.float64)
@@ -238,12 +262,25 @@ class VolumeDataset(torch.utils.data.Dataset):
 
         # Apply optional bounding box constraint
         if vol_cfg.bounding_box is not None:
+            if len(vol_cfg.bounding_box) != len(img_sp_idx):
+                raise ValueError(
+                    f"Volume {vol_cfg.name!r}: bounding_box has "
+                    f"{len(vol_cfg.bounding_box)} entries but image has "
+                    f"{len(img_sp_idx)} spatial dims ({img_spatial!r})"
+                )
             bb = np.array(vol_cfg.bounding_box)
             min_center = np.maximum(min_center, bb[:, 0].astype(np.float64))
             max_center = np.minimum(max_center, bb[:, 1].astype(np.float64))
 
         min_center = np.ceil(min_center).astype(np.int64)
         max_center = np.floor(max_center).astype(np.int64)
+
+        if np.any(min_center > max_center):
+            raise ValueError(
+                f"Volume {vol_cfg.name!r}: no valid center coordinates "
+                f"(min={min_center.tolist()}, max={max_center.tolist()}). "
+                f"Patch size is too large for this volume or bounding_box is too restrictive."
+            )
 
         return VolumeInfo(
             config=vol_cfg,
@@ -255,7 +292,7 @@ class VolumeDataset(torch.utils.data.Dataset):
             lbl_spatial_axes=lbl_spatial,
             img_spatial_idx=img_sp_idx,
             lbl_spatial_idx=lbl_sp_idx,
-            image_dtype=image_meta.scales[finest_scale].dtype,
+            image_dtype=image_dtype,
             finest_voxel_size=finest_spatial_factors,
             relative_scale_factors=relative_scale_factors,
             label_relative_scale_factors=label_relative_scale_factors,
@@ -307,18 +344,22 @@ class VolumeDataset(torch.utils.data.Dataset):
     def __len__(self) -> int:
         return self.config.samples_per_epoch
 
-    def _build_img_slices(
-        self, origin: np.ndarray, read_shape: np.ndarray, vol_info: VolumeInfo
+    @staticmethod
+    def _build_slices(
+        origin: np.ndarray,
+        read_shape: np.ndarray,
+        axes: str,
+        spatial_idx: list[int],
     ) -> tuple:
-        """Build slices for image array: spatial dims get crop, channel gets slice(None)."""
+        """Build slices for an array: spatial dims get crop, non-spatial dims get slice(None)."""
         slices = []
         sp_i = 0
-        for dim_i, ax_char in enumerate(vol_info.img_axes):
-            if dim_i in vol_info.img_spatial_idx:
+        for dim_i in range(len(axes)):
+            if dim_i in spatial_idx:
                 slices.append(slice(int(origin[sp_i]), int(origin[sp_i] + read_shape[sp_i])))
                 sp_i += 1
             else:
-                slices.append(slice(None))  # channel dim: take all
+                slices.append(slice(None))
         return tuple(slices)
 
     def __getitem__(self, idx: int) -> dict:
@@ -356,6 +397,7 @@ class VolumeDataset(torch.utils.data.Dataset):
 
         # Label intermediate: "l" + lbl_axes, output = output_axes minus "c"
         lbl_output_axes = self.config.output_axes.replace("c", "")
+        lbl_perm: tuple[int, ...] | None = None
         if vol_info.lbl_axes is not None:
             lbl_intermediate = "l" + vol_info.lbl_axes
             lbl_perm = compute_permutation(lbl_intermediate, lbl_output_axes)
@@ -376,7 +418,6 @@ class VolumeDataset(torch.utils.data.Dataset):
         bboxes: list[np.ndarray] = []
 
         # Phase 1: Compute slices and issue all reads concurrently via ts.Batch
-        level_info: list[dict] = []
         img_futures: list[ts.Future] = []
         lbl_futures: list[ts.Future | None] = []
 
@@ -414,16 +455,17 @@ class VolumeDataset(torch.utils.data.Dataset):
                 )
                 bboxes.append(bbox)
 
-                img_slices = self._build_img_slices(origin, eff_shape, vol_info)
+                img_slices = self._build_slices(
+                    origin, eff_shape, vol_info.img_axes, vol_info.img_spatial_idx
+                )
                 img_futures.append(vol_stores["img"][level][img_slices].read(batch=batch))
 
                 if vol_info.config.label_key and level in vol_stores["label"]:
                     lbl_rel_factors = vol_info.label_relative_scale_factors[level]
                     lbl_center = np.floor(center / lbl_rel_factors).astype(np.int64)
                     lbl_origin = lbl_center - eff_half
-                    lbl_slices = tuple(
-                        slice(int(o), int(o + s))
-                        for o, s in zip(lbl_origin, eff_shape)
+                    lbl_slices = self._build_slices(
+                        lbl_origin, eff_shape, vol_info.lbl_axes, vol_info.lbl_spatial_idx
                     )
                     lbl_futures.append(vol_stores["label"][level][lbl_slices].read(batch=batch))
                 else:
@@ -450,9 +492,7 @@ class VolumeDataset(torch.utils.data.Dataset):
                         # Rearrange to (C, spatial...) so F.interpolate sees (N,C,D,H,W)
                         c_pos = vol_info.img_axes.index("c")
                         perm = [c_pos] + list(vol_info.img_spatial_idx)
-                        inv_perm = [0] * len(perm)
-                        for i, p in enumerate(perm):
-                            inv_perm[p] = i
+                        inv_perm = invert_permutation(perm)
                         patch_t = patch_t.permute(perm)
                         patch_t = F.interpolate(
                             patch_t.unsqueeze(0),
@@ -487,10 +527,13 @@ class VolumeDataset(torch.utils.data.Dataset):
         img_tensor = img_stacked.permute(img_perm).float()
         if vol_info.config.normalize and np.issubdtype(vol_info.image_dtype, np.integer):
             img_tensor = img_tensor / float(np.iinfo(vol_info.image_dtype).max)
-        label_tensor = (
-            torch.from_numpy(np.stack(label_crops)).permute(lbl_perm).long()
-            if label_crops else None
-        )
+        if label_crops:
+            assert lbl_perm is not None, "lbl_perm must be set when labels are present"
+            label_tensor = (
+                torch.from_numpy(np.stack(label_crops)).permute(lbl_perm).long()
+            )
+        else:
+            label_tensor = None
 
         # Stack bboxes: (L, 2, Nd_spatial) in output spatial order, physical units
         bbox_arr = np.stack(bboxes)

--- a/src/miao/store.py
+++ b/src/miao/store.py
@@ -37,7 +37,7 @@ def open_store(
         "kvstore": {"driver": "file", "path": str(path)},
     }
 
-    kwargs: dict = {"open": True}
+    kwargs: dict[str, object] = {"open": True}
     if context is not None:
         kwargs["context"] = context
 

--- a/src/miao/zarr_meta.py
+++ b/src/miao/zarr_meta.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
@@ -53,11 +53,6 @@ def detect_zarr_version(path: Path | str) -> ZarrVersion:
         if "multiscales" in attrs:
             ds_path = attrs["multiscales"][0]["datasets"][0]["path"]
             return detect_zarr_version(path / ds_path)
-
-    # Zarr3 group-level check
-    zarr_json = path / "zarr.json"
-    if zarr_json.exists():
-        return "zarr3"
 
     raise ValueError(f"Cannot detect zarr version at {path}")
 


### PR DESCRIPTION
## Summary

Review uncovered several latent bugs and dead code in the patch-sampling pipeline. This PR fixes them and simplifies a few hot paths. All 35 existing tests remain green.

### Bugs fixed

| ID | File | What was wrong |
|----|------|----------------|
| B1 | `dataset.py` | Label slicing ignored non-spatial dims (e.g. `czyx` labels would index wrong dims). Now uses the same slice builder as images. |
| B2 | `dataset.py` | `lbl_perm` was conditionally defined and unconditionally referenced — risked `UnboundLocalError`. Hoisted + asserted at use. |
| B3 | `dataset.py` | Label relative scale factors were divided by the **image's** finest voxel size. If the two pyramids had different finest-scale resolutions, label patches were silently misaligned. Now validates they match and raises with a clear message. |
| B4 | `dataset.py` | When `patch_size` was too large or `bounding_box` too restrictive, `min_center > max_center` caused a cryptic per-sample `ValueError` from `np.random.randint`. Now raises at dataset construction with the offending bounds. |
| B5 | `config.py` + `dataset.py` | `bounding_box` had no shape validation. Added a pydantic validator (pair shape + `min <= max`) and a dim-count check against the OME-NGFF spatial axes. |
| B6 | `dataset.py` | Class docstring claimed output shape was `(1, L, *output_axes_dims)` — wrong (no leading 1; `L` is already in `output_axes_dims`). Corrected. |
| B7 | `dataset.py` | `normalize=True` silently no-oped on non-integer dtypes despite the README promising auto-normalization. Now emits a one-time `UserWarning` per volume. |

### Simplifications

- Added `axes.invert_permutation` helper; reused in `map_patch_size_to_input` (replacing an `O(n²)` `perm.index` loop) and in `dataset.py`'s iso-interpolation branch.
- Unified `_build_img_slices` and the inline label-slice loop into one `_build_slices` staticmethod. This wires in the previously-dead `lbl_spatial_idx` field.
- Removed dead imports (`field`, `reorient`, `ScaleMetadata`) and dead locals (`half_patch`, `level_info`).
- Deleted an unreachable `zarr.json` branch in `detect_zarr_version`.
- `_print_summary` uses `enumerate` instead of `self._volumes.index(vi)`.
- Tightened `kwargs: dict` → `kwargs: dict[str, object]` in `store.open_store`.

## Test plan

- [x] `pytest tests/ -xvs` — 35/35 pass
- [x] B7 warning fires on existing float32 fixtures (visible in test output)
- [x] Follow-up: add fixtures for `czyx` labels (exercises B1), oversized patch (B4), mis-sized `bounding_box` (B5), image/label voxel mismatch (B3), and non-integer-dtype normalize (B7). Noted in the review plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)