### PR TITLE
Add sequential sampling mode with configurable overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,34 @@ Each sample:
 | `samples_per_epoch` | Number of samples per epoch |
 | `isotropic` | Flag to determine if images and labels should be upsampled to be isotropic |
 | `cache_bytes` | TensorStore cache size in bytes (default: 1 GB) |
+| `sampling` | `"random"` (default) or `"sequential"` — see below |
+| `overlap` | Voxels of overlap between adjacent patches in sequential mode (default: `0`). Integer (same for all axes) or list in `output_axes` spatial order, e.g. `[16, 16, 8]` |
 
 Input axes are auto-detected from OME-NGFF metadata (`multiscales.axes`).
+
+### Sequential sampling (inference / evaluation)
+
+Set `sampling: "sequential"` to iterate over the entire volume in a deterministic grid instead of random sampling. Useful for dense inference and evaluation.
+
+```yaml
+sampling: "sequential"
+overlap: 16              # or per-axis list e.g. [16, 16, 8]
+```
+
+```python
+dataset = VolumeDataset(config)
+# len(dataset) = total grid positions across all volumes
+
+loader = DataLoader(dataset, batch_size=4, shuffle=False)  # shuffle=False required
+
+for batch in loader:
+    img  = batch["img"]
+    meta = batch["meta"]
+    # meta["grid_index"]: tuple e.g. (2, 0, 3) = position in the grid per axis
+    # use grid_index to stitch patch predictions back into a full-volume output
+```
+
+In sequential mode `samples_per_epoch` and per-volume `weight` are ignored. For multiple volumes, all positions of volume 0 are yielded before volume 1.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,27 @@ for batch in loader:
 
 In sequential mode `samples_per_epoch` and per-volume `weight` are ignored. For multiple volumes, all positions of volume 0 are yielded before volume 1.
 
+### Isotropic + sequential sampling
+
+When `isotropic: true` and `sampling: "sequential"` are used together, the grid is built in **isotropic output space** rather than storage space. This ensures full coverage of the isotropic output volume with no gaps, even when the source data is anisotropic.
+
+For example, with voxel sizes 9×9×20 nm (Z is ~2.2× coarser), the grid produces ~2.2× more positions along Z than it would in storage space — matching the interpolated output resolution.
+
+```yaml
+isotropic: true
+sampling: "sequential"
+overlap: 16
+```
+
+Two coordinate fields are available in `meta`:
+
+| Field | Space | Use case |
+|---|---|---|
+| `meta["coordinate"]` | Storage voxels | Debugging, cross-referencing with on-disk data |
+| `meta["isotropic_coordinate"]` | Isotropic output voxels | Stitching inference predictions into a dense volume |
+
+`isotropic_coordinate` is present whenever `isotropic: true` (both random and sequential modes) and absent when `isotropic: false`.
+
 ## Requirements
 
 - Python >= 3.10

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,1194 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/pytorch/
+    indexes:
+    - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-12.4.127-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-12.4.127-h85509e4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cupti-12.4.127-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-libraries-12.4.1-ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-12.4.127-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvtx-12.4.127-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-opencl-12.4.127-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-runtime-12.4.1-ha804496_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-12.4-h3060b56_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcublas-12.4.5.8-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufft-11.2.1.3-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.9.1.3-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.3.5.147-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcusolver-11.6.1.9-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcusparse-12.3.1.170-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.0-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnpp-12.2.5.30-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvfatbin-12.4.127-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-12.4.127-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjpeg-12.3.1.117-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-15.0.7-h0cdce71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2023.2.0-ha770c72_50498.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/pytorch/linux-64/pytorch-2.5.1-py3.12_cuda12.4_cudnn9.1.0_0.tar.bz2
+      - conda: https://conda.anaconda.org/pytorch/linux-64/pytorch-cuda-12.4-hc786d27_7.tar.bz2
+      - conda: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cuda.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-hb700be7_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/pytorch/linux-64/torchtriton-3.1.0-py312.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/53/78c98ef5c8b2b784453487f3e4d6c017b20747c58b470393e230c78d18e8/numcodecs-0.16.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/8a/590bb60a190d414abd2f83dd5b5148722d0c5d310a73e21b7a60ab98cf00/tensorstore-0.1.82-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/0a/469e2bd01be1490336e6c8707386845655d59261543315778a3ccc7e8019/zarr-3.2.1-py3-none-any.whl
+      - pypi: ./
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+  build_number: 7
+  sha256: c0cddb66070dd6355311f7667ce2acccf70d1013edaa6e97f22859502fefdb22
+  md5: 887b70e1d607fba7957aa02f9ee0d939
+  depends:
+  - llvm-openmp >=9.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 8244
+  timestamp: 1764092331208
+- pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+  name: annotated-types
+  version: 0.7.0
+  sha256: 1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53
+  requires_dist:
+  - typing-extensions>=4.0.0 ; python_full_version < '3.9'
+  requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: a9a9125029a66905fc9e932dfd4f595be3a59a30db37fd7bf4a675a5c6151d62
+  md5: 349aef876b1d8c9dccae01de20d5b385
+  depends:
+  - mkl
+  track_features:
+  - blas_mkl
+  license: BSD 3-clause
+  purls: []
+  size: 1381
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
+  md5: d2ffd7602c02f2b316fd921d39876885
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 260182
+  timestamp: 1771350215188
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+  sha256: c9dbcc8039a52023660d6d1bbf87594a93dd69c6ac5a2a44323af2c92976728d
+  md5: e18ad67cf881dcadee8b8d9e2f8e5f73
+  depends:
+  - __unix
+  license: ISC
+  purls: []
+  size: 131039
+  timestamp: 1776865545798
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
+  noarch: generic
+  sha256: d3e9bbd7340199527f28bbacf947702368f31de60c433a16446767d3c6aaf6fe
+  md5: f54c1ffb8ecedb85a8b7fcde3a187212
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi * *_cp312
+  license: Python-2.0
+  purls: []
+  size: 46463
+  timestamp: 1772728929620
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-12.4.127-he02047a_2.conda
+  sha256: d8ad0be647dad6378119c110572bbf9f6b1e8c820393ed159d45f02588979c07
+  md5: a748faa52331983fc3adcc3b116fe0e4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-cudart_linux-64 12.4.127 h85509e4_2
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 22563
+  timestamp: 1715710703269
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-12.4.127-h85509e4_2.conda
+  sha256: 1f1b3e0bf6b5e665860ecbdf509c1e02760c14d25e3f3893a712f90f7f8a5abc
+  md5: 329163110a96514802e9e64d971edf43
+  depends:
+  - cuda-version >=12.4,<12.5.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 186886
+  timestamp: 1715710690964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cupti-12.4.127-he02047a_2.conda
+  sha256: db9ebc57fd583711bbdd12e54d00e4153a7b414f929f77fca2f44547c02204b8
+  md5: 46422ef1b1161fb180027e50c598ecd0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 1918773
+  timestamp: 1715665119069
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-libraries-12.4.1-ha770c72_1.conda
+  sha256: cb30e83f33c7480caa68a1e35e6ff4102d17ff0a94239ca18555afff1df2f70e
+  md5: 6bb3f998485d4344a7539e0b218b3fc1
+  depends:
+  - cuda-cudart 12.4.127.*
+  - cuda-nvrtc 12.4.127.*
+  - cuda-opencl 12.4.127.*
+  - libcublas 12.4.5.8.*
+  - libcufft 11.2.1.3.*
+  - libcufile 1.9.1.3.*
+  - libcurand 10.3.5.147.*
+  - libcusolver 11.6.1.9.*
+  - libcusparse 12.3.1.170.*
+  - libnpp 12.2.5.30.*
+  - libnvfatbin 12.4.127.*
+  - libnvjitlink 12.4.127.*
+  - libnvjpeg 12.3.1.117.*
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 20180
+  timestamp: 1713304266920
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-12.4.127-he02047a_2.conda
+  sha256: c4aba5e152526db7cad7c8a5191497b0c6365c912ed845dc9c427d29893486a1
+  md5: 80baf6262f4a1a0dde42d85aaa393402
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 18825627
+  timestamp: 1715711095870
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvtx-12.4.127-he02047a_2.conda
+  sha256: 8f499785edaec6198a934e8a9dd1f8b6f79aabcc135962d6050dd7328c76d3dc
+  md5: 656a004b6e44f50ce71c65cab0d429b4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 31691
+  timestamp: 1715731339952
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-opencl-12.4.127-he02047a_1.conda
+  sha256: 75d912a70719a9d0bca9f234a79a857815d8feec3c54c145e6e41589de4ff5be
+  md5: 1e98deda07c14d26c80d124cf0eb011a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - ocl-icd >=2.3.2,<3.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 30406
+  timestamp: 1715711329543
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-runtime-12.4.1-ha804496_0.conda
+  sha256: 61a593347c91a9bcd18329f7aa780bd1fb1e20dd1b61b16a451bd4a6b60dabf0
+  md5: 48829f4ef6005ae8d4867b99168ff2b8
+  depends:
+  - __linux
+  - cuda-libraries 12.4.1.*
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 20034
+  timestamp: 1712683445348
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-12.4-h3060b56_3.conda
+  sha256: 571d32fbd0dc8df6e85c14d1757549927e272af9c70b935d7e3a553ab0b0b4da
+  md5: c9a3fe8b957176e1a8452c6f3431b0d8
+  constrains:
+  - cudatoolkit 12.4|12.4.*
+  - __cuda >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 21022
+  timestamp: 1709765922936
+- pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
+  name: donfig
+  version: 0.8.1.post1
+  sha256: 2a3175ce74a06109ff9307d90a230f81215cbac9a751f4d1c6194644b8204f9d
+  requires_dist:
+  - pyyaml
+  - sphinx>=4.0.0 ; extra == 'docs'
+  - numpydoc ; extra == 'docs'
+  - pytest ; extra == 'docs'
+  - cloudpickle ; extra == 'docs'
+  - pytest ; extra == 'test'
+  - cloudpickle ; extra == 'test'
+  requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+  sha256: 6b471a18372bbd52bdf32fc965f71de3bc1b5219418b8e6b3875a67a7b08c483
+  md5: 8fa8358d022a3a9bd101384a808044c6
+  depends:
+  - python >=3.10
+  license: Unlicense
+  purls:
+  - pkg:pypi/filelock?source=compressed-mapping
+  size: 34211
+  timestamp: 1776621506566
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+  sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
+  md5: c94a5994ef49749880a8139cf9afcbe1
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  purls: []
+  size: 460055
+  timestamp: 1718980856608
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
+  sha256: 6fbdd686d04a0d8c48efe92795137d3bba55a4325acd7931978fd8ea5e24684d
+  md5: fedbe80d864debab03541e1b447fc12a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gmp >=6.3.0,<7.0a0
+  - libgcc >=14
+  - mpc >=1.3.1,<2.0a0
+  - mpfr >=4.2.1,<5.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  purls:
+  - pkg:pypi/gmpy2?source=hash-mapping
+  size: 253171
+  timestamp: 1773245116314
+- pypi: https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
+  name: google-crc32c
+  version: 1.8.0
+  sha256: 14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411
+  requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+  sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
+  md5: c80d8a3b84358cb967fa81e7075fbc8a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 12723451
+  timestamp: 1773822285671
+- pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
+  name: iniconfig
+  version: 2.3.0
+  sha256: f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
+  requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+  sha256: fc9ca7348a4f25fed2079f2153ecdcf5f9cf2a0bc36c4172420ca09e1849df7b
+  md5: 04558c96691bed63104678757beb4f8d
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/jinja2?source=hash-mapping
+  size: 120685
+  timestamp: 1764517220861
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
+  md5: 18335a698559cdbcd86150a48bf54ba6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.45.1
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 728002
+  timestamp: 1774197446916
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcublas-12.4.5.8-he02047a_2.conda
+  sha256: 168e664423e875f7107697dfa7935399675872ea8abffa92621db98007258d66
+  md5: d446adae085aa1ff37c44b69988a6f06
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-nvrtc
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 240665617
+  timestamp: 1715711552741
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcufft-11.2.1.3-he02047a_2.conda
+  sha256: 242e1ed210a85fc0dc2a4e86bf0b75120f1768ab66497502c5e6d69e801bf9dc
+  md5: d2641a67c207946ef96f1328c4a8e8ed
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 174980358
+  timestamp: 1715711515585
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.9.1.3-he02047a_2.conda
+  sha256: 7fa7a608d52064b724241e4026f0e0cc244c6f725623e2c26c810be99822fa28
+  md5: a051267bcb1912467c81d802a7d3465e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 924329
+  timestamp: 1715720836466
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.3.5.147-he02047a_2.conda
+  sha256: 7db821fc8f566dbb8d4e40dae62edb07d638db8c028d677a0063ece66872d19c
+  md5: 9c4886d513fd477df88d411cd274c202
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 41590169
+  timestamp: 1715711553620
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcusolver-11.6.1.9-he02047a_2.conda
+  sha256: df4f8a94bffb59dc3da28fb5a892c1ef2553f8afd49f141d3e2da8c92f276a56
+  md5: 9f6877f8936be962f598db5e9b8efc51
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libcublas >=12.4.5.8,<12.5.0a0
+  - libcusparse >=12.3.1.170,<12.4.0a0
+  - libgcc-ng >=12
+  - libnvjitlink >=12.4.127,<13.0.0a0
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 81594879
+  timestamp: 1715711788074
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcusparse-12.3.1.170-he02047a_2.conda
+  sha256: f2254e41c93a8c3529690c19350556708182ef699ca658c6554eeb7eb4b8c3de
+  md5: 1c4c7ff54dc5b947f2ab8f5ff8a28dae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libnvjitlink >=12.4.127,<13.0.0a0
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 117818451
+  timestamp: 1715711610677
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.0-hecca717_0.conda
+  sha256: ea33c40977ea7a2c3658c522230058395bc2ee0d89d99f0711390b6a1ee80d12
+  md5: a3b390520c563d78cc58974de95a03e5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.0.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 77241
+  timestamp: 1777846112704
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+  sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
+  md5: a360c33a5abe61c07959e449fa1453eb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 58592
+  timestamp: 1769456073053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+  sha256: faf7d2017b4d718951e3a59d081eb09759152f93038479b768e3d612688f83f5
+  md5: 0aa00f03f9e39fb9876085dee11a85d4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_18
+  - libgomp 15.2.0 he0feb66_18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 1041788
+  timestamp: 1771378212382
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
+  sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
+  md5: d5e96b1ed75ca01906b3d2469b4ce493
+  depends:
+  - libgcc 15.2.0 he0feb66_18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 27526
+  timestamp: 1771378224552
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+  sha256: 2cf160794dda62cf93539adf16d26cfd31092829f2a2757dbdd562984c1b110a
+  md5: 0ed3aa3e3e6bc85050d38881673a692f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 2449916
+  timestamp: 1765103845133
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+  sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
+  md5: 915f5995e94f60e9a4826e0b0920ee88
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-only
+  purls: []
+  size: 790176
+  timestamp: 1754908768807
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+  md5: b88d90cad08e6bc8ad540cb310a761fb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  purls: []
+  size: 113478
+  timestamp: 1775825492909
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnpp-12.2.5.30-he02047a_2.conda
+  sha256: d8c97716825955c48681f4a3cde2f0cbbacc77c91b4cd944d4906f63385487df
+  md5: a96a1edd18bee676cf2dcca251d3d6a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 99461229
+  timestamp: 1715711634268
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+  sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
+  md5: d864d34357c3b65a4b731f78c0801dc4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-only
+  license_family: GPL
+  purls: []
+  size: 33731
+  timestamp: 1750274110928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvfatbin-12.4.127-he02047a_2.conda
+  sha256: d40f37532f86cbbe63439489be0e88561819190392cc519c69365b3fc47a2c5b
+  md5: d746b76642b4ac6e40f1219405672beb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 792025
+  timestamp: 1715711761341
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-12.4.127-he02047a_2.conda
+  sha256: 31382c8ef388a51bd2c283a239e037b8b30f9c7ecf6ec9744824445b59db39b6
+  md5: 303845d6c48bf4185dc4138634650468
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version>=12.0.0,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 16571958
+  timestamp: 1715711715842
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjpeg-12.3.1.117-he02047a_2.conda
+  sha256: 49a182f8da4ba30fbfee9692976d9da349371175c9c9576768d4754a51fef326
+  md5: 8f3ed0e41a4b505de40b4f96f4bfb0fa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 2491500
+  timestamp: 1715711780068
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+  sha256: 54cdcd3214313b62c2a8ee277e6f42150d9b748264c1b70d958bf735e420ef8d
+  md5: 7dc38adcbf71e6b38748e919e16e0dce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  size: 954962
+  timestamp: 1777986471789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+  sha256: 78668020064fdaa27e9ab65cd2997e2c837b564ab26ce3bf0e58a2ce1a525c6e
+  md5: 1b08cd684f34175e4514474793d44bcb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.2.0 he0feb66_18
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 5852330
+  timestamp: 1771378262446
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
+  sha256: 3c902ffd673cb3c6ddde624cdb80f870b6c835f8bf28384b0016e7d444dd0145
+  md5: 6235adb93d064ecdf3d44faee6f468de
+  depends:
+  - libstdcxx 15.2.0 h934c35e_18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 27575
+  timestamp: 1771378314494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+  sha256: bc1b08c92626c91500fd9f26f2c797f3eb153b627d53e9c13cd167f1e12b2829
+  md5: 38ffe67b78c9d4de527be8315e5ada2c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 40297
+  timestamp: 1775052476770
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+  sha256: 3bc5551720c58591f6ea1146f7d1539c734ed1c40e7b9f5cb8cb7e900c509aba
+  md5: 995d8c8bad2a3cc8db14675a153dec2b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libxml2-16 2.15.3 hca6bf5a_0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 46810
+  timestamp: 1776376751152
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+  sha256: 3d44f737c5ae52d5af32682cc1530df433f401f8e58a7533926536244127572a
+  md5: e79d2c2f24b027aa8d5ab1b1ba3061e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - libxml2 2.15.3
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 559775
+  timestamp: 1776376739004
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+  md5: d87ff7921124eccd67248aa483c23fec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 63629
+  timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-15.0.7-h0cdce71_0.conda
+  sha256: 7c67d383a8b1f3e7bf9e046e785325c481f6868194edcfb9d78d261da4ad65d4
+  md5: 589c9a3575a050b583241c3d688ad9aa
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openmp 15.0.7|15.0.7.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  purls: []
+  size: 3268766
+  timestamp: 1673584331056
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+  sha256: 5f3aad1f3a685ed0b591faad335957dbdb1b73abfd6fc731a0d42718e0653b33
+  md5: 93a4752d42b12943a355b682ee43285b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
+  size: 26057
+  timestamp: 1772445297924
+- pypi: ./
+  name: miao-io
+  version: 0.1.3
+  sha256: e92c04284d13cb39f34103e05661828aa80323b9db0b76eba66add6dea17bfb2
+  requires_dist:
+  - torch>=2.0
+  - tensorstore>=0.1.60
+  - pyyaml>=6.0
+  - pydantic>=2.0
+  - numpy>=1.24
+  - pytest>=7.0 ; extra == 'dev'
+  - zarr>=2.16 ; extra == 'dev'
+  requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2023.2.0-ha770c72_50498.conda
+  sha256: cafca5b96c1431757909fa11942cb57056870d3fede2eb6bbc138f5ed86679a4
+  md5: 0ef2680575d5b0d9082c287c7eef11f8
+  depends:
+  - _openmp_mutex * *_kmp_*
+  - _openmp_mutex >=4.5
+  - tbb 2021.*
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  purls: []
+  size: 163765767
+  timestamp: 1757090808863
+- pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: ml-dtypes
+  version: 0.5.4
+  sha256: 9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff
+  requires_dist:
+  - numpy>=1.21
+  - numpy>=1.21.2 ; python_full_version >= '3.10'
+  - numpy>=1.23.3 ; python_full_version >= '3.11'
+  - numpy>=1.26.0 ; python_full_version >= '3.12'
+  - numpy>=2.1.0 ; python_full_version >= '3.13'
+  - absl-py ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-xdist ; extra == 'dev'
+  - pylint>=2.6.0 ; extra == 'dev'
+  - pyink ; extra == 'dev'
+  requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
+  sha256: c1fdeebc9f8e4f51df265efca4ea20c7a13911193cc255db73cccb6e422ae486
+  md5: 770d00bf57b5599c4544d61b61d8c6c6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gmp >=6.3.0,<7.0a0
+  - libgcc >=14
+  - mpfr >=4.2.2,<5.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 100245
+  timestamp: 1774472435333
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+  sha256: 8690f550a780f75d9c47f7ffc15f5ff1c149d36ac17208e50eda101ca16611b9
+  md5: 85ce2ffa51ab21da5efa4a9edc5946aa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gmp >=6.3.0,<7.0a0
+  - libgcc >=14
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  size: 730422
+  timestamp: 1773413915171
+- conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
+  sha256: 5bbf2f8179ec43d34d67ca8e4989d216c1bdb4b749fe6cb40e86ebf88c1b5300
+  md5: 2e81b32b805f406d23ba61938a184081
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/mpmath?source=hash-mapping
+  size: 464918
+  timestamp: 1773662068273
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
+  md5: fc21868a1a5aacc937e7a18747acb8a5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 918956
+  timestamp: 1777422145199
+- conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
+  sha256: f6a82172afc50e54741f6f84527ef10424326611503c64e359e25a19a8e4c1c6
+  md5: a2c1eeadae7a309daed9d62c96012a2b
+  depends:
+  - python >=3.11
+  - python
+  constrains:
+  - numpy >=1.25
+  - scipy >=1.11.2
+  - matplotlib-base >=3.8
+  - pandas >=2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/networkx?source=hash-mapping
+  size: 1587439
+  timestamp: 1765215107045
+- pypi: https://files.pythonhosted.org/packages/fb/53/78c98ef5c8b2b784453487f3e4d6c017b20747c58b470393e230c78d18e8/numcodecs-0.16.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: numcodecs
+  version: 0.16.5
+  sha256: ad1a379a45bd3491deab8ae6548313946744f868c21d5340116977ea3be5b1d6
+  requires_dist:
+  - numpy>=1.24
+  - typing-extensions
+  - msgpack ; extra == 'msgpack'
+  - zfpy>=1.0.0 ; extra == 'zfpy'
+  - pcodec>=0.3,<0.4 ; extra == 'pcodec'
+  - crc32c>=2.7 ; extra == 'crc32c'
+  - google-crc32c>=1.5 ; extra == 'google-crc32c'
+  - sphinx ; extra == 'docs'
+  - sphinx-issues ; extra == 'docs'
+  - pydata-sphinx-theme ; extra == 'docs'
+  - numpydoc ; extra == 'docs'
+  - coverage ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pyzstd ; extra == 'test'
+  - importlib-metadata ; extra == 'test-extras'
+  - crc32c ; extra == 'test-extras'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: numpy
+  version: 2.4.4
+  sha256: 81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e
+  requires_python: '>=3.11'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
+  sha256: 2254dae821b286fb57c61895f2b40e3571a070910fdab79a948ff703e1ea807b
+  md5: 56f8947aa9d5cf37b0b3d43b83f34192
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - opencl-headers >=2024.10.24
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 106742
+  timestamp: 1743700382939
+- conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
+  sha256: 8de2f0cd8a659b01abf86e7fbb8cea4f28ada62fd288429a2bbc040db1b98dd0
+  md5: c930c8052d780caa41216af7de472226
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 55754
+  timestamp: 1773844383536
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
+  md5: da1b85b6a87e141f5140bb9924cecab0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 3167099
+  timestamp: 1775587756857
+- pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
+  name: packaging
+  version: '26.2'
+  sha256: 5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+  name: pluggy
+  version: 1.6.0
+  sha256: e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+  requires_dist:
+  - pre-commit ; extra == 'dev'
+  - tox ; extra == 'dev'
+  - pytest ; extra == 'testing'
+  - pytest-benchmark ; extra == 'testing'
+  - coverage ; extra == 'testing'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl
+  name: pydantic
+  version: 2.13.3
+  sha256: 6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927
+  requires_dist:
+  - annotated-types>=0.6.0
+  - pydantic-core==2.46.3
+  - typing-extensions>=4.14.1
+  - typing-inspection>=0.4.2
+  - email-validator>=2.0.0 ; extra == 'email'
+  - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: pydantic-core
+  version: 2.46.3
+  sha256: fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395
+  requires_dist:
+  - typing-extensions>=4.14.1
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
+  name: pygments
+  version: 2.20.0
+  sha256: 81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+  requires_dist:
+  - colorama>=0.4.6 ; extra == 'windows-terminal'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
+  name: pytest
+  version: 9.0.3
+  sha256: 2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9
+  requires_dist:
+  - colorama>=0.4 ; sys_platform == 'win32'
+  - exceptiongroup>=1 ; python_full_version < '3.11'
+  - iniconfig>=1.0.1
+  - packaging>=22
+  - pluggy>=1.5,<2
+  - pygments>=2.7.2
+  - tomli>=1 ; python_full_version < '3.11'
+  - argcomplete ; extra == 'dev'
+  - attrs>=19.2 ; extra == 'dev'
+  - hypothesis>=3.56 ; extra == 'dev'
+  - mock ; extra == 'dev'
+  - requests ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  - xmlschema ; extra == 'dev'
+  requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
+  sha256: a44655c1c3e1d43ed8704890a91e12afd68130414ea2c0872e154e5633a13d7e
+  md5: 7eccb41177e15cc672e1babe9056018e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.7.4,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - liblzma >=5.8.2,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.51.2,<4.0a0
+  - libuuid >=2.41.3,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.5,<4.0a0
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 31608571
+  timestamp: 1772730708989
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+  build_number: 8
+  sha256: 80677180dd3c22deb7426ca89d6203f1c7f1f256f2d5a94dc210f6e758229809
+  md5: c3efd25ac4d74b1584d2f7a57195ddf1
+  constrains:
+  - python 3.12.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 6958
+  timestamp: 1752805918820
+- conda: https://conda.anaconda.org/pytorch/linux-64/pytorch-2.5.1-py3.12_cuda12.4_cudnn9.1.0_0.tar.bz2
+  sha256: 8183ab363b7892f67ba3660929f1c3f4f8646e4a2a02d499d387acc0509764c3
+  md5: 42164c6ce8e563c20a542686a8b9b964
+  depends:
+  - blas * mkl
+  - filelock
+  - jinja2
+  - llvm-openmp <16
+  - mkl >=2018
+  - networkx
+  - python >=3.12,<3.13.0a0
+  - pytorch-cuda >=12.4,<12.5
+  - pytorch-mutex 1.0 cuda
+  - pyyaml
+  - sympy
+  - torchtriton 3.1.0
+  - typing_extensions
+  constrains:
+  - cpuonly <0
+  license: BSD 3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/torch?source=hash-mapping
+  size: 1571072276
+  timestamp: 1729655770987
+- conda: https://conda.anaconda.org/pytorch/linux-64/pytorch-cuda-12.4-hc786d27_7.tar.bz2
+  sha256: 4ce6352f6270673aaf335909da2bbdd70ad8aaae489319e1e3a5ac0aae720314
+  md5: 06635b1bbf5e2fef4a8b9b282500cd7b
+  depends:
+  - cuda-cudart >=12.4,<12.5
+  - cuda-cupti >=12.4,<12.5
+  - cuda-libraries >=12.4,<12.5
+  - cuda-nvrtc >=12.4,<12.5
+  - cuda-nvtx >=12.4,<12.5
+  - cuda-runtime >=12.4,<12.5
+  - libcublas >=12.4.5.8,<12.5.2.13
+  - libcufft >=11.2.1.3,<11.2.3.18
+  - libcusolver >=11.6.1.9,<11.6.2.40
+  - libcusparse >=12.3.1.170,<12.4.1.18
+  - libnpp >=12.2.5.30,<12.3.0.116
+  - libnvjitlink >=12.4.127,<12.5.40
+  - libnvjpeg >=12.3.1.117,<12.3.2.38
+  purls: []
+  size: 7189
+  timestamp: 1724179791784
+- conda: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cuda.tar.bz2
+  build_number: 100
+  sha256: c16316183f51b74ca5eee4dcb8631052f328c0bbf244176734a0b7d390b81ee3
+  md5: a948316e36fb5b11223b3fcfa93f8358
+  purls: []
+  size: 2906
+  timestamp: 1628062930777
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+  sha256: cb142bfd92f6e55749365ddc244294fa7b64db6d08c45b018ff1c658907bfcbf
+  md5: 15878599a87992e44c059731771591cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
+  size: 198293
+  timestamp: 1770223620706
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+  md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 345073
+  timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+  sha256: 1c8057e6875eba958aa8b3c1a072dc9a75d013f209c26fd8125a5ebd3abbec0c
+  md5: 32d866e43b25275f61566b9391ccb7b5
+  depends:
+  - __unix
+  - cpython
+  - gmpy2 >=2.0.8
+  - mpmath >=1.1.0,<1.5
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/sympy?source=hash-mapping
+  size: 4661767
+  timestamp: 1771952371059
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-hb700be7_5.conda
+  sha256: a49f26ddf4b954670733586e42e41e43d13f7e8e589b70ead8b7512657404d82
+  md5: d4cfccb9ccd4f7cbfde7353b5e20d31a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libhwloc >=2.12.2,<2.12.3.0a0
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 171042
+  timestamp: 1767886637012
+- pypi: https://files.pythonhosted.org/packages/f9/8a/590bb60a190d414abd2f83dd5b5148722d0c5d310a73e21b7a60ab98cf00/tensorstore-0.1.82-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: tensorstore
+  version: 0.1.82
+  sha256: d4182300d8ffa172e961e79c6bd89e38ce6bc5cd3abf1a7dacb22c2396ce40b7
+  requires_dist:
+  - numpy>=1.22.0
+  - ml-dtypes>=0.5.0
+  requires_python: '>=3.11'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+  sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
+  md5: cffd3bdd58090148f4cfcd831f4b26ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3301196
+  timestamp: 1769460227866
+- conda: https://conda.anaconda.org/pytorch/linux-64/torchtriton-3.1.0-py312.tar.bz2
+  build_number: 1
+  sha256: f0beb429b3834a3796626642829a7e4bb9d4fe6477c8dc614a55e5c4f15a6a05
+  md5: bb4b2d07cb6b9b476e78740c08ba69fe
+  depends:
+  - filelock
+  - python >=3.12,<3.13.0a0
+  - pytorch
+  license: MIT
+  purls:
+  - pkg:pypi/triton?source=hash-mapping
+  size: 244939186
+  timestamp: 1727971107041
+- pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
+  name: typing-inspection
+  version: 0.4.2
+  sha256: 4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7
+  requires_dist:
+  - typing-extensions>=4.12.0
+  requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
+  md5: 0caa1af407ecff61170c9437a808404d
+  depends:
+  - python >=3.10
+  - python
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/typing-extensions?source=hash-mapping
+  size: 51692
+  timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
+  md5: ad659d0a2b3e47e38d829aa8cad2d610
+  license: LicenseRef-Public-Domain
+  purls: []
+  size: 119135
+  timestamp: 1767016325805
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+  sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
+  md5: a77f85f77be52ff59391544bfe73390a
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 85189
+  timestamp: 1753484064210
+- pypi: https://files.pythonhosted.org/packages/88/0a/469e2bd01be1490336e6c8707386845655d59261543315778a3ccc7e8019/zarr-3.2.1-py3-none-any.whl
+  name: zarr
+  version: 3.2.1
+  sha256: f78cdd3d9687ad0e9f9cba2c5683b64f0c52589c19f685eeabe872e93cc0d2c7
+  requires_dist:
+  - donfig>=0.8
+  - google-crc32c>=1.5
+  - numcodecs>=0.14
+  - numpy>=2
+  - packaging>=22.0
+  - typing-extensions>=4.13
+  - cast-value-rs ; extra == 'cast-value-rs'
+  - typer ; extra == 'cli'
+  - cupy-cuda12x ; extra == 'gpu'
+  - universal-pathlib ; extra == 'optional'
+  - fsspec>=2023.10.0 ; extra == 'remote'
+  - obstore>=0.5.1 ; extra == 'remote'
+  requires_python: '>=3.12'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+  md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 601375
+  timestamp: 1764777111296

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,20 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/miao"]
+
+[tool.pixi.workspace]
+channels = ["conda-forge", "pytorch"]
+platforms = ["linux-64"]
+
+[tool.pixi.dependencies]
+python = ">=3.10"
+pytorch = {version = ">=2.0", channel = "pytorch"}
+
+[tool.pixi.pypi-dependencies]
+miao-io = {path = ".", editable = true, extras = ["dev"]}
+
+[tool.pixi.tasks]
+test = "pytest tests/ -v"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/miao/config.py
+++ b/src/miao/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 
 import yaml
 from pydantic import BaseModel, field_validator, model_validator
@@ -60,6 +60,8 @@ class MiaoConfig(BaseModel):
     samples_per_epoch: int = 1000
     cache_bytes: int = 1 << 30  # 1 GB
     file_io_concurrency: int = 64
+    sampling: Literal["random", "sequential"] = "random"
+    overlap: Union[int, list[int]] = 0  # voxels; in output_axes spatial order (same as patch_size)
 
     @field_validator("output_axes")
     @classmethod
@@ -104,6 +106,25 @@ class MiaoConfig(BaseModel):
         names = [v.name for v in self.volumes]
         if len(names) != len(set(names)):
             raise ValueError("Volume names must be unique")
+        return self
+
+    @model_validator(mode="after")
+    def validate_overlap(self) -> "MiaoConfig":
+        if self.sampling != "sequential":
+            return self
+        ov = self.overlap if isinstance(self.overlap, list) else [self.overlap] * len(self.patch_size)
+        if len(ov) != len(self.patch_size):
+            raise ValueError(
+                f"overlap has {len(ov)} elements but patch_size has {len(self.patch_size)} — "
+                "they must match (both in output_axes spatial order)"
+            )
+        for i, (o, p) in enumerate(zip(ov, self.patch_size)):
+            if o < 0:
+                raise ValueError(f"overlap[{i}]={o} must be >= 0")
+            if o >= p:
+                raise ValueError(
+                    f"overlap[{i}]={o} must be < patch_size[{i}]={p} (stride would be <= 0)"
+                )
         return self
 
 

--- a/src/miao/dataset.py
+++ b/src/miao/dataset.py
@@ -102,6 +102,11 @@ class VolumeDataset(torch.utils.data.Dataset):
         for vol_cfg in config.volumes:
             self._volumes.append(self._resolve_volume(vol_cfg))
 
+        # Build sequential grid before printing summary (summary reports grid size)
+        self._grid: list[tuple[int, np.ndarray, tuple]] = []
+        if config.sampling == "sequential":
+            self._build_sequential_grid()
+
         # Print summary
         self._print_summary()
 
@@ -110,8 +115,13 @@ class VolumeDataset(torch.utils.data.Dataset):
 
     def _print_summary(self) -> None:
         """Print a summary of detected metadata for all volumes."""
+        if self.config.sampling == "sequential":
+            ov = self.config.overlap
+            mode_str = f"sequential, {len(self._grid)} total positions, overlap={ov}"
+        else:
+            mode_str = f"random, {self.config.samples_per_epoch} samples/epoch"
         print(f"VolumeDataset: {len(self._volumes)} volume(s), "
-              f"{self.config.samples_per_epoch} samples/epoch, "
+              f"{mode_str}, "
               f"patch_size={self.config.patch_size}")
         for vi in self._volumes:
             finest = min(vi.config.scales)
@@ -303,6 +313,49 @@ class VolumeDataset(torch.utils.data.Dataset):
             iso_read_shapes=iso_read_shapes,
         )
 
+    def _build_sequential_grid(self) -> None:
+        """Precompute flat list of (vol_idx, center, grid_index) for sequential sampling.
+
+        center is in image spatial axis order (matching min_center/max_center).
+        grid_index is a tuple of per-axis position indices within the grid for that volume,
+        useful for stitching patch predictions back into a full-volume output.
+        """
+        from itertools import product as iproduct
+
+        output_spatial = spatial_axes(self.config.output_axes)
+        ov = self.config.overlap
+        if isinstance(ov, int):
+            ov = [ov] * len(self.config.patch_size)
+
+        for vol_idx, vol_info in enumerate(self._volumes):
+            # Map overlap from output_axes spatial order → input (storage) spatial order,
+            # matching the convention used by vol_info.read_shape.
+            overlap_input = map_patch_size_to_input(
+                ov, vol_info.img_spatial_axes, output_spatial
+            )
+            stride = np.array(vol_info.read_shape) - np.array(overlap_input)
+
+            # Generate valid center positions per spatial axis
+            ranges: list[list[int]] = []
+            for i in range(len(vol_info.read_shape)):
+                lo = int(vol_info.min_center[i])
+                hi = int(vol_info.max_center[i])
+                positions = list(range(lo, hi + 1, int(stride[i])))
+                if not positions:
+                    raise ValueError(
+                        f"Volume {vol_info.config.name!r}: no valid center positions along "
+                        f"spatial axis {i} (min_center={lo} > max_center={hi}). "
+                        f"Volume may be too small for the requested patch_size."
+                    )
+                if positions[-1] < hi:
+                    positions.append(hi)
+                ranges.append(positions)
+
+            # Cartesian product → flat list; last axis varies fastest
+            for grid_idx in iproduct(*[range(len(r)) for r in ranges]):
+                center = np.array([ranges[ax][grid_idx[ax]] for ax in range(len(ranges))])
+                self._grid.append((vol_idx, center, grid_idx))
+
     def _get_worker_id(self) -> int:
         worker_info = torch.utils.data.get_worker_info()
         return worker_info.id if worker_info is not None else 0
@@ -343,6 +396,8 @@ class VolumeDataset(torch.utils.data.Dataset):
         return self._worker_stores[worker_id]
 
     def __len__(self) -> int:
+        if self.config.sampling == "sequential":
+            return len(self._grid)
         return self.config.samples_per_epoch
 
     def _build_img_slices(
@@ -362,8 +417,12 @@ class VolumeDataset(torch.utils.data.Dataset):
     def __getitem__(self, idx: int) -> dict:
         stores = self._get_stores()
 
-        # Pick a volume based on sampling weights
-        vol_idx = np.random.choice(len(self._volumes), p=self._probabilities)
+        # Pick volume (and center in sequential mode) based on sampling strategy
+        grid_index: tuple | None = None
+        if self.config.sampling == "sequential":
+            vol_idx, center, grid_index = self._grid[idx]
+        else:
+            vol_idx = np.random.choice(len(self._volumes), p=self._probabilities)
         vol_info = self._volumes[vol_idx]
         vol_stores = stores[vol_info.config.name]
         output_spatial = spatial_axes(self.config.output_axes)
@@ -404,13 +463,14 @@ class VolumeDataset(torch.utils.data.Dataset):
                 lbl_intermediate = "l" + vol_info.lbl_axes
             lbl_perm = compute_permutation(lbl_intermediate, lbl_output_axes)
 
-        # Pick a random center coordinate at finest scale (spatial dims, image spatial order)
-        center = np.array(
-            [
-                np.random.randint(lo, hi + 1)
-                for lo, hi in zip(vol_info.min_center, vol_info.max_center)
-            ]
-        )
+        # Pick center coordinate (random mode only; sequential already set center above)
+        if self.config.sampling == "random":
+            center = np.array(
+                [
+                    np.random.randint(lo, hi + 1)
+                    for lo, hi in zip(vol_info.min_center, vol_info.max_center)
+                ]
+            )
 
         read_shape = np.array(vol_info.read_shape)
         half_patch = read_shape // 2
@@ -572,5 +632,7 @@ class VolumeDataset(torch.utils.data.Dataset):
                 "volume": vol_info.config.name,
                 "coordinate": center.tolist(),
                 "scale_levels": vol_info.config.scales,
+                # grid_index only present in sequential mode; None breaks DataLoader collation
+                **({"grid_index": grid_index} if grid_index is not None else {}),
             },
         }

--- a/src/miao/dataset.py
+++ b/src/miao/dataset.py
@@ -74,6 +74,9 @@ class VolumeInfo:
     read_shape: list[int]
     # Per-scale: spatial read shape for isotropic mode (None if isotropic=False)
     iso_read_shapes: dict[int, np.ndarray] | None
+    # Per-axis zoom factor from storage to isotropic space (None if isotropic=False)
+    # e.g., [5, 1, 1] for voxel sizes [40, 8, 8] nm (Z is 5x coarser)
+    iso_zoom_factors: np.ndarray | None = None
 
 
 class VolumeDataset(torch.utils.data.Dataset):
@@ -104,6 +107,7 @@ class VolumeDataset(torch.utils.data.Dataset):
 
         # Build sequential grid before printing summary (summary reports grid size)
         self._grid: list[tuple[int, np.ndarray, tuple]] = []
+        self._grid_iso_centers: list[np.ndarray] = []
         if config.sampling == "sequential":
             self._build_sequential_grid()
 
@@ -117,7 +121,8 @@ class VolumeDataset(torch.utils.data.Dataset):
         """Print a summary of detected metadata for all volumes."""
         if self.config.sampling == "sequential":
             ov = self.config.overlap
-            mode_str = f"sequential, {len(self._grid)} total positions, overlap={ov}"
+            iso_tag = " (isotropic grid)" if self.config.isotropic else ""
+            mode_str = f"sequential, {len(self._grid)} total positions, overlap={ov}{iso_tag}"
         else:
             mode_str = f"random, {self.config.samples_per_epoch} samples/epoch"
         print(f"VolumeDataset: {len(self._volumes)} volume(s), "
@@ -233,8 +238,9 @@ class VolumeDataset(torch.utils.data.Dataset):
                     lbl_all[lbl_sp_idx] / finest_spatial_factors
                 )
 
-        # Compute per-level isotropic read shapes if requested
+        # Compute per-level isotropic read shapes and zoom factors if requested
         iso_read_shapes: dict[int, np.ndarray] | None = None
+        iso_zoom_factors: np.ndarray | None = None
         if self.config.isotropic:
             iso_read_shapes = {}
             for level in vol_cfg.scales:
@@ -244,6 +250,9 @@ class VolumeDataset(torch.utils.data.Dataset):
                 iso_read_shapes[level] = np.ceil(
                     np.array(read_shape, dtype=np.float64) * target_iso / level_voxel
                 ).astype(np.int64)
+            # Zoom factor: how many isotropic voxels per storage voxel, per axis
+            target_iso_voxel = finest_spatial_factors.min()
+            iso_zoom_factors = finest_spatial_factors / target_iso_voxel
 
         # Compute valid center coordinate range (spatial dims only)
         finest_all_shape = np.array(image_meta.scales[finest_scale].shape)
@@ -311,6 +320,7 @@ class VolumeDataset(torch.utils.data.Dataset):
             max_center=max_center,
             read_shape=read_shape,
             iso_read_shapes=iso_read_shapes,
+            iso_zoom_factors=iso_zoom_factors,
         )
 
     def _build_sequential_grid(self) -> None:
@@ -319,6 +329,11 @@ class VolumeDataset(torch.utils.data.Dataset):
         center is in image spatial axis order (matching min_center/max_center).
         grid_index is a tuple of per-axis position indices within the grid for that volume,
         useful for stitching patch predictions back into a full-volume output.
+
+        When isotropic=True, the grid is built in isotropic output space so that
+        stride and overlap semantics match the isotropic output tensor. Grid positions
+        are converted back to storage coordinates for reading. Isotropic centers are
+        stored in self._grid_iso_centers for inclusion in meta["isotropic_coordinate"].
         """
         from itertools import product as iproduct
 
@@ -328,33 +343,74 @@ class VolumeDataset(torch.utils.data.Dataset):
             ov = [ov] * len(self.config.patch_size)
 
         for vol_idx, vol_info in enumerate(self._volumes):
-            # Map overlap from output_axes spatial order → input (storage) spatial order,
-            # matching the convention used by vol_info.read_shape.
+            # Map overlap from output_axes spatial order → input (storage) spatial order
             overlap_input = map_patch_size_to_input(
                 ov, vol_info.img_spatial_axes, output_spatial
             )
-            stride = np.array(vol_info.read_shape) - np.array(overlap_input)
 
-            # Generate valid center positions per spatial axis
-            ranges: list[list[int]] = []
-            for i in range(len(vol_info.read_shape)):
-                lo = int(vol_info.min_center[i])
-                hi = int(vol_info.max_center[i])
-                positions = list(range(lo, hi + 1, int(stride[i])))
-                if not positions:
-                    raise ValueError(
-                        f"Volume {vol_info.config.name!r}: no valid center positions along "
-                        f"spatial axis {i} (min_center={lo} > max_center={hi}). "
-                        f"Volume may be too small for the requested patch_size."
+            if vol_info.iso_zoom_factors is not None:
+                # --- Isotropic mode: build grid in isotropic output space ---
+                zoom = vol_info.iso_zoom_factors
+                iso_min = vol_info.min_center * zoom
+                iso_max = vol_info.max_center * zoom
+
+                # patch_size mapped to input (storage) axis order — this is the
+                # isotropic output size per axis (what the caller gets after interpolation)
+                patch_input = map_patch_size_to_input(
+                    self.config.patch_size, vol_info.img_spatial_axes, output_spatial
+                )
+                iso_stride = np.array(patch_input) - np.array(overlap_input)
+
+                ranges: list[list[int]] = []
+                for i in range(len(patch_input)):
+                    lo = int(iso_min[i])
+                    hi = int(iso_max[i])
+                    positions = list(range(lo, hi + 1, int(iso_stride[i])))
+                    if not positions:
+                        raise ValueError(
+                            f"Volume {vol_info.config.name!r}: no valid center positions "
+                            f"along spatial axis {i} in isotropic space "
+                            f"(iso_min={lo} > iso_max={hi}). "
+                            f"Volume may be too small for the requested patch_size."
+                        )
+                    if positions[-1] < hi:
+                        positions.append(hi)
+                    ranges.append(positions)
+
+                for grid_idx in iproduct(*[range(len(r)) for r in ranges]):
+                    iso_center = np.array(
+                        [ranges[ax][grid_idx[ax]] for ax in range(len(ranges))]
                     )
-                if positions[-1] < hi:
-                    positions.append(hi)
-                ranges.append(positions)
+                    storage_center = np.round(iso_center / zoom).astype(np.int64)
+                    storage_center = np.clip(
+                        storage_center, vol_info.min_center, vol_info.max_center
+                    )
+                    self._grid.append((vol_idx, storage_center, grid_idx))
+                    self._grid_iso_centers.append(iso_center)
+            else:
+                # --- Non-isotropic: build grid in storage space ---
+                stride = np.array(vol_info.read_shape) - np.array(overlap_input)
 
-            # Cartesian product → flat list; last axis varies fastest
-            for grid_idx in iproduct(*[range(len(r)) for r in ranges]):
-                center = np.array([ranges[ax][grid_idx[ax]] for ax in range(len(ranges))])
-                self._grid.append((vol_idx, center, grid_idx))
+                ranges: list[list[int]] = []
+                for i in range(len(vol_info.read_shape)):
+                    lo = int(vol_info.min_center[i])
+                    hi = int(vol_info.max_center[i])
+                    positions = list(range(lo, hi + 1, int(stride[i])))
+                    if not positions:
+                        raise ValueError(
+                            f"Volume {vol_info.config.name!r}: no valid center positions "
+                            f"along spatial axis {i} (min_center={lo} > max_center={hi}). "
+                            f"Volume may be too small for the requested patch_size."
+                        )
+                    if positions[-1] < hi:
+                        positions.append(hi)
+                    ranges.append(positions)
+
+                for grid_idx in iproduct(*[range(len(r)) for r in ranges]):
+                    center = np.array(
+                        [ranges[ax][grid_idx[ax]] for ax in range(len(ranges))]
+                    )
+                    self._grid.append((vol_idx, center, grid_idx))
 
     def _get_worker_id(self) -> int:
         worker_info = torch.utils.data.get_worker_info()
@@ -624,6 +680,15 @@ class VolumeDataset(torch.utils.data.Dataset):
             bbox_arr = bbox_arr - finest_center
         bbox_tensor = torch.from_numpy(bbox_arr).float()
 
+        # Compute isotropic coordinate if applicable
+        iso_coord = None
+        if vol_info.iso_zoom_factors is not None:
+            if self.config.sampling == "sequential" and self._grid_iso_centers:
+                iso_coord = self._grid_iso_centers[idx].tolist()
+            else:
+                # Random mode: convert storage center to isotropic space
+                iso_coord = (center.astype(np.float64) * vol_info.iso_zoom_factors).tolist()
+
         return {
             "img": img_tensor,
             "label": label_tensor,
@@ -632,6 +697,7 @@ class VolumeDataset(torch.utils.data.Dataset):
                 "volume": vol_info.config.name,
                 "coordinate": center.tolist(),
                 "scale_levels": vol_info.config.scales,
+                **({"isotropic_coordinate": iso_coord} if iso_coord is not None else {}),
                 # grid_index only present in sequential mode; None breaks DataLoader collation
                 **({"grid_index": grid_index} if grid_index is not None else {}),
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,10 +19,12 @@ def _create_ome_ngff_zarr2(
     axes: list[dict] | None = None,
     dtype: str = "float32",
     fill_value: float | None = None,
+    base_scale_factors: list[float] | None = None,
 ) -> None:
     """Create an OME-NGFF compliant zarr2 multiscale group.
 
     Each scale level is downsampled by 2x in all dimensions.
+    base_scale_factors sets the voxel size at level 0 (e.g., [5, 1, 1] for anisotropic).
     """
     if axes is None:
         ndim = len(base_shape)
@@ -42,7 +44,10 @@ def _create_ome_ngff_zarr2(
     for level in range(num_scales):
         scale_factor = 2**level
         level_shape = tuple(s // scale_factor for s in base_shape)
-        scale_factors = [float(scale_factor)] * len(base_shape)
+        if base_scale_factors is not None:
+            scale_factors = [sf * scale_factor for sf in base_scale_factors]
+        else:
+            scale_factors = [float(scale_factor)] * len(base_shape)
 
         # Create array with deterministic data
         rng = np.random.RandomState(42 + level)
@@ -140,6 +145,32 @@ def zarr2_volume_xyz(tmp_path: Path) -> Path:
             {"name": "z", "type": "space", "unit": "micrometer"},
         ],
         dtype="float32",
+    )
+
+    return zarr_path
+
+
+@pytest.fixture
+def zarr2_volume_anisotropic(tmp_path: Path) -> Path:
+    """Create a zarr2 OME-NGFF volume with anisotropic voxel sizes.
+
+    Shape: (20, 100, 100) in ZYX, voxel sizes [5, 1, 1] (Z is 5x coarser).
+    In isotropic space at 1-unit resolution, the volume is 100x100x100.
+    """
+    zarr_path = tmp_path / "test_volume_aniso.zarr"
+
+    _create_ome_ngff_zarr2(
+        zarr_path,
+        group_key="raw",
+        base_shape=(20, 100, 100),
+        num_scales=1,
+        axes=[
+            {"name": "z", "type": "space", "unit": "nanometer"},
+            {"name": "y", "type": "space", "unit": "nanometer"},
+            {"name": "x", "type": "space", "unit": "nanometer"},
+        ],
+        dtype="uint8",
+        base_scale_factors=[5.0, 1.0, 1.0],
     )
 
     return zarr_path

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,6 +1,7 @@
 """Tests for VolumeDataset."""
 
 from pathlib import Path
+from itertools import product as iproduct
 
 import numpy as np
 import pytest
@@ -309,3 +310,182 @@ class TestVolumeDataset:
         ds = VolumeDataset(cfg)
         sample = ds[0]
         assert torch.allclose(sample["img"], torch.full_like(sample["img"], expected))
+
+    # ── Random mode: grid_index is None ──────────────────────────────────────
+
+    def test_random_mode_no_grid_index(self, zarr2_volume: Path):
+        """Random mode: meta does not contain 'grid_index' (avoids DataLoader collation issues)."""
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            samples_per_epoch=5,
+        )
+        ds = VolumeDataset(cfg)
+        for i in range(5):
+            assert "grid_index" not in ds[i]["meta"]
+
+    # ── Sequential sampling ───────────────────────────────────────────────────
+
+    def test_sequential_basic(self, zarr2_volume: Path):
+        """Sequential: __len__ equals precomputed grid size; sample shape is correct."""
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            sampling="sequential",
+        )
+        ds = VolumeDataset(cfg)
+        # 64^3 volume, patch 8^3, overlap 0, stride 8
+        # min_center=4, max_center=60 per axis → positions [4,12,...,60] = 8 per axis
+        assert len(ds) == 8 ** 3
+        sample = ds[0]
+        assert sample["img"].shape == (1, 8, 8, 8)
+        assert sample["img"].dtype == torch.float32
+
+    def test_sequential_deterministic(self, zarr2_volume: Path):
+        """Same idx always returns the same coordinate and grid_index."""
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            sampling="sequential",
+        )
+        ds = VolumeDataset(cfg)
+        for idx in [0, 7, 63, 511]:
+            s1 = ds[idx]
+            s2 = ds[idx]
+            assert s1["meta"]["coordinate"] == s2["meta"]["coordinate"]
+            assert s1["meta"]["grid_index"] == s2["meta"]["grid_index"]
+
+    def test_sequential_grid_index_in_meta(self, zarr2_volume: Path):
+        """Sequential mode: meta['grid_index'] is a tuple; first is (0,0,0)."""
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            sampling="sequential",
+        )
+        ds = VolumeDataset(cfg)
+        first = ds[0]
+        last = ds[len(ds) - 1]
+        assert isinstance(first["meta"]["grid_index"], tuple)
+        assert first["meta"]["grid_index"] == (0, 0, 0)
+        assert last["meta"]["grid_index"] == (7, 7, 7)
+
+    def test_sequential_full_coverage(self, zarr2_volume: Path):
+        """Every voxel in the volume is covered by at least one patch."""
+        vol_shape = (64, 64, 64)
+        patch_size = [8, 8, 8]
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=patch_size,
+            sampling="sequential",
+        )
+        ds = VolumeDataset(cfg)
+        covered = np.zeros(vol_shape, dtype=bool)
+        half = [p // 2 for p in patch_size]  # [4, 4, 4]
+        for i in range(len(ds)):
+            z, y, x = ds[i]["meta"]["coordinate"]  # center in ZYX order
+            covered[z - half[0]: z + half[0], y - half[1]: y + half[1], x - half[2]: x + half[2]] = True
+        assert covered.all(), "Some voxels not covered by any patch"
+
+    def test_sequential_zero_overlap_stride_equals_patch(self, zarr2_volume: Path):
+        """overlap=0: consecutive patches are exactly patch_size apart (no overlap, no gap)."""
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            sampling="sequential",
+            overlap=0,
+        )
+        ds = VolumeDataset(cfg)
+        # grid[0] = (z0, y0, x0), grid[1] = (z0, y0, x1) — last axis varies fastest
+        c0 = ds._grid[0][1]  # center of first patch
+        c1 = ds._grid[1][1]  # center of second patch (next x position)
+        assert abs(int(c1[-1]) - int(c0[-1])) == 8  # stride = patch_size - overlap = 8
+
+    def test_sequential_overlap(self, zarr2_volume: Path):
+        """overlap=4: stride=4, consecutive patch centers are 4 apart; grid is larger."""
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            sampling="sequential",
+            overlap=4,
+        )
+        ds = VolumeDataset(cfg)
+        # stride=4, positions per axis: range(4, 61, 4) → [4,8,...,60] = 15 positions
+        assert len(ds) == 15 ** 3
+        c0 = ds._grid[0][1]
+        c1 = ds._grid[1][1]
+        assert abs(int(c1[-1]) - int(c0[-1])) == 4
+
+    def test_sequential_multi_volume(self, zarr2_volume: Path):
+        """Multi-volume: all volumes are iterated; grid_index resets per volume."""
+        cfg = MiaoConfig(
+            volumes=[
+                {"name": "vol_a", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]},
+                {"name": "vol_b", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]},
+            ],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            sampling="sequential",
+        )
+        ds = VolumeDataset(cfg)
+        per_vol = 8 ** 3  # 512 per volume
+        assert len(ds) == 2 * per_vol
+        # vol_a fills first half, vol_b fills second half
+        assert ds[0]["meta"]["volume"] == "vol_a"
+        assert ds[per_vol - 1]["meta"]["volume"] == "vol_a"
+        assert ds[per_vol]["meta"]["volume"] == "vol_b"
+        # grid_index resets at volume boundary
+        assert ds[0]["meta"]["grid_index"] == (0, 0, 0)
+        assert ds[per_vol]["meta"]["grid_index"] == (0, 0, 0)
+
+    def test_sequential_overlap_too_large_raises(self, zarr2_volume: Path):
+        """overlap >= patch_size raises ValueError at config creation time."""
+        with pytest.raises(ValueError, match="overlap"):
+            MiaoConfig(
+                volumes=[{"name": "test", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]}],
+                n_scales=1,
+                output_axes="lzyx",
+                patch_size=[8, 8, 8],
+                sampling="sequential",
+                overlap=8,  # equal to patch_size → stride=0
+            )
+
+    def test_sequential_overlap_negative_raises(self, zarr2_volume: Path):
+        """Negative overlap raises ValueError."""
+        with pytest.raises(ValueError, match="overlap"):
+            MiaoConfig(
+                volumes=[{"name": "test", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]}],
+                n_scales=1,
+                output_axes="lzyx",
+                patch_size=[8, 8, 8],
+                sampling="sequential",
+                overlap=-1,
+            )
+
+    def test_sequential_per_axis_overlap(self, zarr2_volume: Path):
+        """Per-axis overlap list: each axis uses its own overlap value."""
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            sampling="sequential",
+            overlap=[4, 0, 0],  # only Z has overlap; in output ZYX order
+        )
+        ds = VolumeDataset(cfg)
+        # Z: stride=4 → 15 positions; Y,X: stride=8 → 8 positions each
+        assert len(ds) == 15 * 8 * 8

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -489,3 +489,106 @@ class TestVolumeDataset:
         ds = VolumeDataset(cfg)
         # Z: stride=4 → 15 positions; Y,X: stride=8 → 8 positions each
         assert len(ds) == 15 * 8 * 8
+
+    # ── Isotropic + sequential sampling ──────────────────────────────────────
+
+    def test_sequential_isotropic_grid_size(self, zarr2_volume_anisotropic: Path):
+        """Isotropic sequential: grid is built in isotropic space, giving more positions."""
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume_anisotropic),
+                       "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[10, 10, 10],
+            sampling="sequential",
+            isotropic=True,
+        )
+        ds = VolumeDataset(cfg)
+        # Anisotropic volume: 20×100×100 storage, voxel [5,1,1]
+        # Isotropic space: 100×100×100 at 1-unit resolution
+        # iso_read_shape = ceil([10,10,10]*[1/5,1,1]) = [2,10,10]
+        # min_center=[1,5,5], max_center=[19,95,95]
+        # iso_min=[5,5,5], iso_max=[95,95,95], iso_stride=[10,10,10]
+        # positions per axis: [5,15,25,...,95] = 10
+        assert len(ds) == 10 ** 3
+
+    def test_sequential_isotropic_coordinates(self, zarr2_volume_anisotropic: Path):
+        """Isotropic sequential: meta has both coordinate and isotropic_coordinate."""
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume_anisotropic),
+                       "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[10, 10, 10],
+            sampling="sequential",
+            isotropic=True,
+        )
+        ds = VolumeDataset(cfg)
+        sample = ds[0]
+        assert "isotropic_coordinate" in sample["meta"]
+        assert "coordinate" in sample["meta"]
+        # First position: iso=[5,5,5], storage=[1,5,5]
+        assert sample["meta"]["isotropic_coordinate"] == [5, 5, 5]
+        assert sample["meta"]["coordinate"] == [1, 5, 5]
+
+    def test_sequential_isotropic_output_shape(self, zarr2_volume_anisotropic: Path):
+        """Isotropic sequential: output tensor matches patch_size (after interpolation)."""
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume_anisotropic),
+                       "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[10, 10, 10],
+            sampling="sequential",
+            isotropic=True,
+        )
+        ds = VolumeDataset(cfg)
+        sample = ds[0]
+        assert sample["img"].shape == (1, 10, 10, 10)
+
+    def test_random_isotropic_has_isotropic_coordinate(self, zarr2_volume_anisotropic: Path):
+        """Random + isotropic: meta includes isotropic_coordinate."""
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume_anisotropic),
+                       "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[10, 10, 10],
+            isotropic=True,
+            samples_per_epoch=5,
+        )
+        ds = VolumeDataset(cfg)
+        sample = ds[0]
+        assert "isotropic_coordinate" in sample["meta"]
+        iso = sample["meta"]["isotropic_coordinate"]
+        storage = sample["meta"]["coordinate"]
+        # Z axis has zoom=5, Y and X have zoom=1
+        assert iso[0] == storage[0] * 5.0
+        assert iso[1] == float(storage[1])
+        assert iso[2] == float(storage[2])
+
+    def test_non_isotropic_no_isotropic_coordinate(self, zarr2_volume: Path):
+        """Non-isotropic mode: meta does not contain isotropic_coordinate."""
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            samples_per_epoch=5,
+        )
+        ds = VolumeDataset(cfg)
+        assert "isotropic_coordinate" not in ds[0]["meta"]
+
+    def test_sequential_isotropic_on_isotropic_volume(self, zarr2_volume: Path):
+        """When volume is already isotropic, iso grid size matches non-iso grid size."""
+        base = dict(
+            volumes=[{"name": "test", "path": str(zarr2_volume), "image_key": "raw", "scales": [0]}],
+            n_scales=1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            sampling="sequential",
+        )
+        ds_no_iso = VolumeDataset(MiaoConfig(**base))
+        ds_iso = VolumeDataset(MiaoConfig(**base, isotropic=True))
+        # Zoom factors are [1,1,1] on isotropic volume → same grid
+        assert len(ds_no_iso) == len(ds_iso)


### PR DESCRIPTION
Closes #2

## What

Adds `sampling="sequential"` to `MiaoConfig` for deterministic grid-based iteration over entire volumes — needed for dense inference and evaluation (e.g. running a linear probe over a full EM volume to get quantitative boundary detection metrics).

## Changes

- **`config.py`**: new `sampling` (`"random"` | `"sequential"`) and `overlap` (int or per-axis list) fields with validation
- **`dataset.py`**: `_build_sequential_grid()` precomputes all `(vol_idx, center, grid_index)` positions at init time; `__len__`, `__getitem__`, and `_print_summary` branch on sampling mode; `meta["grid_index"]` tuple added in sequential mode for patch stitching
- **`tests/test_dataset.py`**: 11 new test cases (grid size, full coverage, determinism, overlap, multi-volume, per-axis overlap, error cases)
- **`README.md`**: documents new config fields and sequential usage example
- **`pyproject.toml`**: adds pixi environment config for development (`pixi run test`)

## Usage

\`\`\`yaml
sampling: "sequential"
overlap: 16            # or per-axis list e.g. [16, 16, 8]
\`\`\`

\`\`\`python
dataset = VolumeDataset(config)   # len = total grid positions
loader = DataLoader(dataset, shuffle=False)

for batch in loader:
    grid_index = batch["meta"]["grid_index"]  # use to stitch predictions
\`\`\`