### PR TITLE
data augmentation + pixel size + patch normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,21 +56,28 @@ as a per-volume override) *instead of* `resolutions`:
 ```yaml
 resolution_sampling:
   strategy: log_uniform     # only option for now (pluggable; gaussian etc. can be added)
-  ranges: [[[8, 8, 8], [64, 64, 64]]]   # one or more [min, max] ranges (output_axes spatial order)
+  ranges: [[[8], [64]]]     # one or more [min, max] ranges; [[v],[w]] = isotropic (per-axis: [[a,b,c],[d,e,f]])
   n_scales: 3               # scales to draw per range — scalar (all ranges) or list (one per range)
   sort: true                # sort the drawn scales fine -> coarse
 ```
 
-`ranges` is a list of `[min, max]` pairs. Each bound is either a per-spatial-axis list or a
-single-element list `[v]`, which is **isotropic** (broadcast to all axes). For example
-`[[[1, 1, 1], [4, 4, 4]]]` and `[[[1], [4]]]` both mean one isotropic range from 1 to 4;
-`[[[1], [2]], [[4], [8]]]` is two ranges. `n_scales` is the number of scales to draw from each
-range — a scalar applies the same count to every range, or pass a list (e.g. `[1, 1]`). The total
-number of scales (the `l` dimension) is the sum.
+`ranges` is a list of `[min, max]` pairs. How each bound is written controls whether the drawn
+resolution is isotropic:
+
+- **Single-element bounds** `[[v], [w]]` are **isotropic**: one value is drawn per scale and
+  broadcast to all axes (cubic voxel). E.g. `[[[1], [4]]]` — one range, cubic, 1 to 4.
+- **Per-axis bounds** `[[a, b, c], [d, e, f]]` draw **each axis independently**, producing an
+  anisotropic voxel. E.g. `[[[1, 1, 1], [4, 4, 4]]]` draws x, y, z separately in 1..4, so a
+  sample might be `[1.8, 3.2, 2.5]` — this is *not* the same as the isotropic `[[[1], [4]]]`.
+
+Multiple ranges are allowed, e.g. `[[[1], [2]], [[4], [8]]]` (two ranges). `n_scales` is the
+number of scales to draw from each range — a scalar applies the same count to every range, or
+pass a list (e.g. `[1, 1]`). The total number of scales (the `l` dimension) is the sum.
 
 Each `__getitem__` draws those resolutions log-uniformly within each range, sorts them
-fine→coarse, and the drawn values are reported in `meta["resolutions"]` (so a model can condition
-on them). The output is always `patch_size` per scale. Constraints: exactly one of
+fine→coarse, and the drawn values are reported both in the top-level `pixel_size` tensor and in
+`meta["resolutions"]` (so a model can condition on them). The output is always `patch_size` per
+scale. Constraints: exactly one of
 `resolutions` / `resolution_sampling` may be set; `resolution_sampling` is incompatible with
 `sampling: "sequential"`; and `sample_windows` requires every range to be isotropic.
 
@@ -93,11 +100,25 @@ loader = DataLoader(
 )
 
 for batch in loader:
-    img = batch["img"]        # (B, L, X, Y, Z) or (B, L, X, Y, Z, C) if channel present
-    label = batch["label"]    # (B, L, X, Y, Z) or None
-    bbox = batch["bbox"]      # (B, L, 2, Nd_spatial)
-    meta = batch["meta"]      # dict with volume name, coordinate, resolutions, source levels
+    img = batch["img"]                # (B, L, X, Y, Z) or (B, L, X, Y, Z, C) if channel present
+    label = batch["label"]            # (B, L, X, Y, Z) or None
+    bbox = batch["bbox"]              # (B, L, 2, Nd_spatial)
+    pixel_size = batch["pixel_size"]  # (B, L, Nd_spatial) — output voxel size per level
+    meta = batch["meta"]              # dict with volume name, coordinate, resolutions, source levels
 ```
+
+#### `pixel_size`
+
+Every sample returns a `pixel_size` tensor of shape `(L, Nd_spatial)` (batched to
+`(B, L, Nd_spatial)`) giving the **physical output voxel size per scale level**, in the same
+physical unit as the zarr's OME `coordinateTransformations` and in `output_axes` spatial order
+(matching `bbox`). It is a first-class tensor at the top level of the batch (not nested under
+`meta`), so the default PyTorch collate stacks it cleanly — convenient for feeding a
+scale-conditioned model.
+
+It reports the resolutions actually used for that sample, so in **random resolution sampling**
+mode it reflects the freshly-drawn values on every `__getitem__` rather than a fixed list. The
+same values (before reordering to output axis order) are also mirrored in `meta["resolutions"]`.
 
 ### How it works
 
@@ -127,6 +148,7 @@ Each sample:
 | `volumes[].normalize` | Auto-normalize images to [0, 1] by dtype max (default: `true`). Also see `normalize_min` / `normalize_max` to set upper and lower normalization bounds|
 | `volumes[].patch_normalize` | Standardize each returned sample to zero mean / unit standard deviation, applied after `normalize` (default: `false`). With multiple scales, the statistics are taken from the coarsest-resolution (largest physical extent) crop and applied to every scale |
 | `volumes[].bounding_box` | Optional `[[min, max], ...]` per spatial axis (finest-level voxels, storage axis order). Every window's read extent — at every scale, including coarser `sample_windows` patches — is kept strictly inside the box. Must be at least as large as the coarsest window, or dataset construction raises. |
+| `volumes[].aug_rot` | If `true` (default: `false`), apply a random axis-aligned rotation/flip to each returned sample — one of the 48 symmetries of the cube. Requires isotropic output. See "Axis-aligned rotation/flip augmentation (`aug_rot`)" below. |
 | `resolutions` | List of desired output resolutions, one tuple per scale. Each tuple is the output voxel size per spatial axis (physical units), in `output_axes` spatial order. The number of scales (the `l` dimension) is `len(resolutions)`. Mutually exclusive with `resolution_sampling` |
 | `resolution_sampling` | Draw resolutions randomly per sample instead of a fixed list: `{strategy, ranges, n_scales, sort}`. See "Random resolution sampling" above. Mutually exclusive with `resolutions` |
 | `output_axes` | Full tensor dim order including `l` (levels), optional `c` (channel), and spatial dims (e.g. `"lcxyz"`, `"lxyz"`) |
@@ -161,6 +183,7 @@ loader = DataLoader(dataset, batch_size=4, shuffle=False)  # shuffle=False requi
 
 for batch in loader:
     img  = batch["img"]
+    pixel_size = batch["pixel_size"]   # (B, L, Nd_spatial) output voxel size per level
     meta = batch["meta"]
     # meta["grid_index"]: tuple e.g. (2, 0, 3) = position in the grid per axis
     # use grid_index to stitch patch predictions back into a full-volume output
@@ -185,6 +208,35 @@ sample_windows: true
 Sampled coarse patch locations stay strictly within any per-volume `bounding_box` (the box bounds every scale's read extent, not just the patch center).
 
 `resolutions` must be listed from finest to coarsest (non-decreasing voxel size per axis, e.g. `[[8,8,8], [16,16,16]]`). Reordering coarser resolutions before finer ones will raise an error.
+
+### Axis-aligned rotation/flip augmentation (`aug_rot`)
+
+Set `aug_rot: true` on a volume to augment each returned sample with a random axis-aligned rotation/flip:
+
+```yaml
+volumes:
+  - name: "raw"
+    path: "/data/sample_A.zarr"
+    image_key: "raw"
+    label_key: "labels/seg"
+    aug_rot: true            # optional, default: false
+```
+
+Each `__getitem__` draws **one** transform uniformly from the 48 symmetries of the cube — the full set of axis-aligned 3D rotations and reflections (3! axis permutations × 2³ per-axis flips = 48). This is the largest augmentation set achievable without interpolation, since every transform maps voxels onto voxels exactly.
+
+The same transform is applied to:
+
+- **the image and its labels** together (so they stay aligned), and
+- **every requested scale** in the multi-scale stack (so the nested scales stay mutually consistent).
+
+**Isotropic output is required.** An axis permutation mixes the spatial axes, which is only meaningful when the output voxels are cubes. Two conditions are checked:
+
+- `patch_size` must be equal across `x`, `y`, `z` (validated when the config is loaded).
+- The output resolution being read must be equal on all spatial axes (validated per sample, since `resolution_sampling` can draw a different resolution each call). With `resolution_sampling`, use isotropic (single-value) bounds.
+
+It is fine for the **underlying stored data** to be anisotropic — e.g. `z` coarser than `x`/`y` and upsampled — as long as the requested **output** resolution is isotropic.
+
+> **Note:** `aug_rot` reorients the returned `img` and `label` tensors only. The `bbox` and `meta.coordinate` still describe the original (pre-augmentation) read location in the source volume; `pixel_size` is unaffected because it is isotropic by construction.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Each sample:
 | `volumes[].label_key` | Optional group key for labels in the same zarr |
 | `volumes[].weight` | Sampling probability weight (default: equal across volumes) |
 | `volumes[].normalize` | Auto-normalize images to [0, 1] by dtype max (default: `true`). Also see `normalize_min` / `normalize_max` to set upper and lower normalization bounds|
+| `volumes[].patch_normalize` | Standardize each returned sample to zero mean / unit standard deviation, applied after `normalize` (default: `false`). With multiple scales, the statistics are taken from the coarsest-resolution (largest physical extent) crop and applied to every scale |
 | `volumes[].bounding_box` | Optional `[[min, max], ...]` per spatial axis (finest-level voxels, storage axis order). Every window's read extent — at every scale, including coarser `sample_windows` patches — is kept strictly inside the box. Must be at least as large as the coarsest window, or dataset construction raises. |
 | `resolutions` | List of desired output resolutions, one tuple per scale. Each tuple is the output voxel size per spatial axis (physical units), in `output_axes` spatial order. The number of scales (the `l` dimension) is `len(resolutions)`. Mutually exclusive with `resolution_sampling` |
 | `resolution_sampling` | Draw resolutions randomly per sample instead of a fixed list: `{strategy, ranges, n_scales, sort}`. See "Random resolution sampling" above. Mutually exclusive with `resolutions` |

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -28,7 +28,7 @@ resolutions: [[8, 8, 8], [16, 16, 16], [32, 32, 32]]
 # Alternatively, draw resolutions randomly per sample (set instead of `resolutions`):
 # resolution_sampling:
 #   strategy: log_uniform   # only option for now (pluggable)
-#   ranges: [[[8, 8, 8], [64, 64, 64]]]   # [min, max] ranges; use [[v], [w]] for isotropic shorthand
+#   ranges: [[[8], [64]]]   # isotropic [min, max] range; use [[a,b,c],[d,e,f]] for per-axis (anisotropic)
 #   n_scales: 3             # scales per range — scalar (all ranges) or list (one per range, e.g. [1, 2])
 #   sort: true              # sort drawn scales fine -> coarse
 output_axes: "lcxyz" # input will be automatically re-ordered to match this axes order (default: "xyz")

--- a/src/miao/config.py
+++ b/src/miao/config.py
@@ -89,6 +89,11 @@ class VolumeConfig(BaseModel):
     # If both omitted: integer images use [0, dtype_max]; float images are unchanged.
     normalize_min: Optional[float] = None
     normalize_max: Optional[float] = None
+    # If True, additionally standardize each returned sample to zero mean / unit standard
+    # deviation (applied after the `normalize` scaling above). With multiple scales, the
+    # statistics are taken from the coarsest-resolution (largest physical extent) crop and
+    # applied to every scale, so the scales stay on a common intensity scale.
+    patch_normalize: bool = False
     # If True, apply a random axis-aligned rotation/flip augmentation to each returned patch —
     # one of the 48 signed permutations of the x/y/z axes (the full symmetry group of the cube:
     # 3! axis permutations x 2^3 per-axis flips). The same transform is applied to the image and

--- a/src/miao/config.py
+++ b/src/miao/config.py
@@ -89,6 +89,15 @@ class VolumeConfig(BaseModel):
     # If both omitted: integer images use [0, dtype_max]; float images are unchanged.
     normalize_min: Optional[float] = None
     normalize_max: Optional[float] = None
+    # If True, apply a random axis-aligned rotation/flip augmentation to each returned patch —
+    # one of the 48 signed permutations of the x/y/z axes (the full symmetry group of the cube:
+    # 3! axis permutations x 2^3 per-axis flips). The same transform is applied to the image and
+    # its labels. Requires isotropic output (checked per sample): the patch must be cubic across
+    # x/y/z and the resolution being read must be equal on all spatial axes — otherwise a
+    # permutation would mix axes of unequal physical size. It is fine for the underlying stored
+    # data to be anisotropic (e.g. z coarser than x/y and upsampled) as long as the requested
+    # output resolution is isotropic.
+    aug_rot: bool = False
     # [[min_0, max_0], ...] in finest-scale voxels, storage axis order. Strictly contains every
     # window's read extent (all scales, including coarser sample_windows patches), not just the
     # patch center. Must be at least as large as the coarsest window.
@@ -352,6 +361,34 @@ class MiaoConfig(BaseModel):
                         f"(non-decreasing per axis). For volume {vol.name!r}, resolution "
                         f"index {i - 1}->{i} is {prev} -> {curr}."
                     )
+        return self
+
+    @model_validator(mode="after")
+    def validate_aug_rot(self) -> "MiaoConfig":
+        """Static checks for volumes with aug_rot: the output must be able to hold the full set
+        of 48 axis-aligned 3D transforms. Per-sample resolution isotropy is checked at read
+        time (it can vary with resolution_sampling)."""
+        from miao.axes import spatial_axes
+
+        if not any(v.aug_rot for v in self.volumes):
+            return self
+        out_spatial = spatial_axes(self.output_axes)
+        missing = [c for c in "xyz" if c not in out_spatial]
+        if missing:
+            raise ValueError(
+                f"aug_rot requires output_axes to contain all of x, y, z (for the full set of "
+                f"48 axis-aligned 3D rotations/flips), but output_axes={self.output_axes!r} is "
+                f"missing {missing}"
+            )
+        # patch_size is in output_axes spatial order; the x/y/z extents must match so that an
+        # axis permutation preserves the tensor shape.
+        xyz_sizes = {c: self.patch_size[out_spatial.index(c)] for c in "xyz"}
+        if len(set(xyz_sizes.values())) != 1:
+            raise ValueError(
+                f"aug_rot requires a cubic patch_size across x, y, z (axis permutations must "
+                f"preserve shape), but got {xyz_sizes} from patch_size={self.patch_size} "
+                f"(output_axes={self.output_axes!r})"
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/miao/dataset.py
+++ b/src/miao/dataset.py
@@ -193,6 +193,28 @@ def _normalize_image_tensor(
     return img_tensor
 
 
+def _coarsest_scale_index(resolutions: list[np.ndarray]) -> int:
+    """Index of the coarsest scale — the largest physical crop, since patch_size is shared."""
+    return int(np.argmax([float(np.prod(np.asarray(r, dtype=np.float64))) for r in resolutions]))
+
+
+def _patch_normalize_image_tensor(
+    img_tensor: torch.Tensor,
+    *,
+    l_dim: int,
+    ref_level: int,
+) -> torch.Tensor:
+    """Standardize a sample to zero mean / unit standard deviation.
+
+    Statistics come from a single scale level and are applied to every level, so the scales of a
+    multi-scale sample stay on a common intensity scale.
+    """
+    ref = img_tensor.index_select(l_dim, torch.tensor([ref_level])).float()
+    std = ref.std().clamp_min(1e-8)
+    out = (img_tensor.float() - ref.mean()) / std
+    return out.to(img_tensor.dtype)
+
+
 @dataclass
 class ScaleResolution:
     """Per-scale resolution of a set of target resolutions to pyramid reads.
@@ -398,6 +420,11 @@ class VolumeDataset(torch.utils.data.Dataset):
                         "    normalize: float dtype unchanged "
                         "(set normalize_min and normalize_max to scale)"
                     )
+            if vi.config.patch_normalize:
+                lines.append(
+                    "    patch_normalize: per-sample zero mean / unit std"
+                    + (" (stats from the coarsest scale)" if self.config.n_scales > 1 else "")
+                )
             print("\n".join(lines))
         dims = ", ".join(c.upper() for c in self.config.output_axes)
         print(f"  output: axes={self.config.output_axes!r}, tensor_shape=({dims})")
@@ -1132,6 +1159,12 @@ class VolumeDataset(torch.utils.data.Dataset):
             normalize_max=vol_info.config.normalize_max,
             image_dtype=vol_info.image_dtype,
         )
+        if vol_info.config.patch_normalize:
+            img_tensor = _patch_normalize_image_tensor(
+                img_tensor,
+                l_dim=self.config.output_axes.index("l"),
+                ref_level=_coarsest_scale_index(scales.resolutions),
+            )
         if label_crops:
             label_tensor = torch.from_numpy(np.stack(label_crops)).permute(lbl_perm).to(vol_info.label_torch_dtype)
         else:

--- a/src/miao/dataset.py
+++ b/src/miao/dataset.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import itertools
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -142,6 +143,35 @@ def _sample_resolutions(
     return [row.tolist() for row in raw]
 
 
+# The 6 permutations of the three spatial axes (x, y, z). Combined with the 2^3 = 8 per-axis
+# flip masks below, these enumerate the 48 signed permutations of the cube (axis-aligned 3D
+# rotations and reflections) that aug_rot draws from.
+_SPATIAL_PERMS: tuple[tuple[int, int, int], ...] = tuple(itertools.permutations(range(3)))
+
+
+def _apply_axis_aligned_aug(
+    tensor: torch.Tensor,
+    spatial_dims: tuple[int, int, int],
+    perm: tuple[int, int, int],
+    flips: tuple[bool, bool, bool],
+) -> torch.Tensor:
+    """Apply one axis-aligned rotation/flip (a signed permutation of the x/y/z axes) to ``tensor``.
+
+    ``spatial_dims`` are the tensor dim indices of (x, y, z). ``perm`` is a permutation of
+    ``(0, 1, 2)`` reordering those three axes; ``flips`` reverses each. Non-spatial dims (l, t, c)
+    are left untouched. Only valid for a cubic patch at isotropic resolution — the caller
+    guarantees this before calling.
+    """
+    flip_dims = [spatial_dims[i] for i in range(3) if flips[i]]
+    if flip_dims:
+        tensor = torch.flip(tensor, dims=flip_dims)
+    # Place the axis currently at spatial slot perm[i] into spatial slot i; identity elsewhere.
+    full_perm = list(range(tensor.ndim))
+    for i in range(3):
+        full_perm[spatial_dims[i]] = spatial_dims[perm[i]]
+    return tensor.permute(full_perm).contiguous()
+
+
 def _normalize_image_tensor(
     img_tensor: torch.Tensor,
     *,
@@ -261,8 +291,12 @@ class VolumeDataset(torch.utils.data.Dataset):
     1. Randomly picks one volume (weighted sampling).
     2. Picks a random coordinate in that volume's finest-scale space.
     3. Extracts patch_size voxels from each requested scale level.
-    4. Returns {"img": Tensor, "label": Tensor, "bbox": Tensor, "meta": dict}.
+    4. Returns {"img": Tensor, "label": Tensor, "bbox": Tensor,
+       "pixel_size": Tensor, "meta": dict}.
        If labels are unavailable, "label" is an empty long tensor.
+       "pixel_size" is (L, Nd_spatial) µm/px per level in output spatial axis
+       order (matching "bbox"); in resolution-sampling mode it reflects the
+       resolutions drawn for that sample.
 
     Tensor shapes are (1, L, *output_axes_dims) where L = number of scale levels.
     Input axes are auto-detected from OME-NGFF metadata.
@@ -616,6 +650,25 @@ class VolumeDataset(torch.utils.data.Dataset):
             )
 
         return min_center, max_center
+
+    def _assert_aug_rot_isotropic(
+        self, vol_info: VolumeInfo, scales: ScaleResolution
+    ) -> None:
+        """Ensure every scale's output resolution is isotropic before applying aug_rot.
+
+        Axis permutations mix spatial axes, so they are only valid when the voxels read for the
+        output are cubic. Checked per __getitem__ because resolutions may be drawn per sample in
+        resolution_sampling mode. The cubic-patch requirement is enforced statically in config.
+        """
+        for s, res in enumerate(scales.resolutions):
+            r = np.asarray(res, dtype=np.float64)
+            if not np.allclose(r, r[0], rtol=1e-6, atol=1e-9):
+                raise ValueError(
+                    f"Volume {vol_info.config.name!r}: aug_rot requires isotropic output "
+                    f"resolution, but scale {s} resolution {r.tolist()} is anisotropic. "
+                    "Axis-aligned rotations mix spatial axes, which is only valid when the "
+                    "voxel size read for the output is equal on every axis."
+                )
 
     def _build_sequential_grid(self) -> None:
         """Precompute flat list of (vol_idx, center, grid_index) for sequential sampling.
@@ -1085,6 +1138,35 @@ class VolumeDataset(torch.utils.data.Dataset):
             # Keep output collate-friendly for default PyTorch DataLoader.
             label_tensor = torch.empty(0, dtype=vol_info.label_torch_dtype)
 
+        # Axis-aligned rotation/flip augmentation: draw one of the 48 signed permutations of the
+        # x/y/z axes and apply the same transform to the image and its labels. Requires isotropic
+        # output (cubic patch enforced in config; resolution checked here).
+        if vol_info.config.aug_rot:
+            self._assert_aug_rot_isotropic(vol_info, scales)
+            perm = _SPATIAL_PERMS[np.random.randint(len(_SPATIAL_PERMS))]
+            flips = (
+                bool(np.random.randint(2)),
+                bool(np.random.randint(2)),
+                bool(np.random.randint(2)),
+            )
+            img_out_axes = self.config.output_axes
+            img_spatial_dims = (
+                img_out_axes.index("x"),
+                img_out_axes.index("y"),
+                img_out_axes.index("z"),
+            )
+            img_tensor = _apply_axis_aligned_aug(img_tensor, img_spatial_dims, perm, flips)
+            if label_crops:
+                lbl_out_axes = self.config.output_axes.replace("c", "")
+                lbl_spatial_dims = (
+                    lbl_out_axes.index("x"),
+                    lbl_out_axes.index("y"),
+                    lbl_out_axes.index("z"),
+                )
+                label_tensor = _apply_axis_aligned_aug(
+                    label_tensor, lbl_spatial_dims, perm, flips
+                )
+
         # Stack bboxes: (L, 2, Nd_spatial) in output spatial order, physical units
         bbox_arr = np.stack(bboxes)
         if self.config.bbox_mode == "relative":
@@ -1093,10 +1175,20 @@ class VolumeDataset(torch.utils.data.Dataset):
             bbox_arr = bbox_arr - finest_center
         bbox_tensor = torch.from_numpy(bbox_arr).float()
 
+        # Per-level physical pixel size: (L, Nd_spatial) in output spatial order,
+        # matching `bbox`. `scales.resolutions` is in image storage spatial order,
+        # so reorder with `spatial_perm` (as bbox does). Recomputed per sample, so
+        # this reflects the actually-drawn resolutions in sampling mode.
+        pixel_size_arr = np.stack(
+            [np.asarray(res, dtype=np.float64)[list(spatial_perm)] for res in scales.resolutions]
+        )
+        pixel_size_tensor = torch.from_numpy(pixel_size_arr).float()
+
         return {
             "img": img_tensor,
             "label": label_tensor,
             "bbox": bbox_tensor,
+            "pixel_size": pixel_size_tensor,
             "meta": {
                 "volume": vol_info.config.name,
                 "coordinate": center.tolist(),

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -141,6 +141,45 @@ class TestVolumeDataset:
         assert meta["source_levels"] == [0, 1, 2]
         assert len(meta["coordinate"]) == 3
 
+    def test_pixel_size_output(self, sample_config: dict):
+        """pixel_size is a (L, Nd_spatial) float tensor matching the requested resolutions."""
+        cfg = MiaoConfig(**sample_config)
+        ds = VolumeDataset(cfg)
+        sample = ds[0]
+
+        assert "pixel_size" in sample
+        ps = sample["pixel_size"]
+        assert isinstance(ps, torch.Tensor)
+        assert ps.dtype == torch.float32
+        # 3 levels, 3 spatial axes
+        assert ps.shape == (3, 3)
+        # output_axes="lzyx" → output spatial order == storage order, so pixel_size
+        # equals the config resolutions exactly.
+        assert torch.allclose(ps, torch.tensor([[1.0, 1, 1], [2, 2, 2], [4, 4, 4]]))
+
+    def test_pixel_size_output_axis_order(self, zarr2_volume: Path):
+        """pixel_size is returned in output spatial order (exercises non-identity perm)."""
+        cfg = MiaoConfig(
+            volumes=[{"name": "test", "path": str(zarr2_volume), "image_key": "raw"}],
+            resolutions=RES_2,
+            output_axes="lxyz",  # storage is zyx → spatial perm is non-trivial
+            patch_size=[8, 8, 8],
+            samples_per_epoch=5,
+        )
+        ds = VolumeDataset(cfg)
+        ps = ds[0]["pixel_size"]
+        # Recovers the config resolutions (given in output spatial order) per level.
+        assert ps.shape == (2, 3)
+        assert torch.allclose(ps, torch.tensor([[1.0, 1, 1], [2, 2, 2]]))
+
+    def test_pixel_size_dataloader(self, sample_config: dict):
+        """Default collate stacks pixel_size to (B, L, Nd_spatial)."""
+        cfg = MiaoConfig(**sample_config)
+        ds = VolumeDataset(cfg)
+        dl = torch.utils.data.DataLoader(ds, batch_size=2, num_workers=0)
+        batch = next(iter(dl))
+        assert batch["pixel_size"].shape == (2, 3, 3)
+
     def test_multiple_volumes_weighted(self, zarr2_volume: Path):
         """Test that volumes are sampled according to weights."""
         cfg = MiaoConfig(
@@ -660,6 +699,23 @@ class TestResolutionSampling:
         first = [tuple(ds[i]["meta"]["resolutions"][0]) for i in range(20)]
         assert len(set(first)) > 1
 
+    def test_pixel_size_reflects_sampled_resolutions(self, zarr2_volume: Path):
+        """In sampling mode, pixel_size is recomputed per sample from the drawn resolutions."""
+        ds = VolumeDataset(self._cfg(zarr2_volume))
+        np.random.seed(4)
+        seen = set()
+        for i in range(20):
+            sample = ds[i]
+            ps = sample["pixel_size"]
+            assert ps.shape == (2, 3)
+            # output_axes="lzyx" → output spatial order == storage order, so pixel_size
+            # matches meta["resolutions"] (which reports the actually-drawn resolutions).
+            expected = torch.tensor(sample["meta"]["resolutions"], dtype=torch.float32)
+            assert torch.allclose(ps, expected)
+            seen.add(tuple(ps[0].tolist()))
+        # Draws genuinely vary across calls (not a constant broadcast).
+        assert len(seen) > 1
+
     def test_seeded_reproducible(self, zarr2_volume: Path):
         ds = VolumeDataset(self._cfg(zarr2_volume))
         np.random.seed(7)
@@ -962,3 +1018,201 @@ class TestChunkAlignedSampling:
         assert len(centers_ax0) > 2, (
             f"Expected diverse centers when chunk > patch, got only {centers_ax0}"
         )
+
+
+class TestAugRotHelper:
+    """Unit tests for the axis-aligned transform helper (no RNG / dataset)."""
+
+    def test_identity(self):
+        from miao.dataset import _apply_axis_aligned_aug
+
+        # "lzyx" → x=3, y=2, z=1
+        t = torch.arange(2 * 4 * 4 * 4).reshape(2, 4, 4, 4)
+        out = _apply_axis_aligned_aug(t, (3, 2, 1), (0, 1, 2), (False, False, False))
+        assert torch.equal(out, t)
+
+    def test_flip_x_only(self):
+        from miao.dataset import _apply_axis_aligned_aug
+
+        t = torch.arange(1 * 4 * 4 * 4).reshape(1, 4, 4, 4)
+        out = _apply_axis_aligned_aug(t, (3, 2, 1), (0, 1, 2), (True, False, False))
+        assert torch.equal(out, torch.flip(t, dims=[3]))
+
+    def test_swap_x_z(self):
+        from miao.dataset import _apply_axis_aligned_aug
+
+        # perm (2,1,0) swaps the x and z slots → transpose of dims 1 (z) and 3 (x).
+        t = torch.arange(1 * 4 * 4 * 4).reshape(1, 4, 4, 4)
+        out = _apply_axis_aligned_aug(t, (3, 2, 1), (2, 1, 0), (False, False, False))
+        assert torch.equal(out, t.transpose(1, 3))
+
+    def test_leaves_nonspatial_dims(self):
+        from miao.dataset import _apply_axis_aligned_aug
+
+        # "lzyxc": l=0, z=1, y=2, x=3, c=4 → spatial dims (x,y,z)=(3,2,1); l and c untouched.
+        t = torch.arange(2 * 4 * 4 * 4 * 3).reshape(2, 4, 4, 4, 3)
+        out = _apply_axis_aligned_aug(t, (3, 2, 1), (1, 2, 0), (True, False, True))
+        assert out.shape == t.shape
+
+    def test_group_has_48_distinct_elements(self):
+        from miao.dataset import _SPATIAL_PERMS, _apply_axis_aligned_aug
+
+        # Distinct labels per voxel so any two different transforms differ.
+        t = torch.arange(1 * 3 * 3 * 3).reshape(1, 3, 3, 3)
+        seen = set()
+        for perm in _SPATIAL_PERMS:
+            for fmask in range(8):
+                flips = (bool(fmask & 1), bool(fmask & 2), bool(fmask & 4))
+                out = _apply_axis_aligned_aug(t, (3, 2, 1), perm, flips)
+                seen.add(out.numpy().tobytes())
+        assert len(_SPATIAL_PERMS) == 6
+        assert len(seen) == 48
+
+
+class TestAugRot:
+    """Per-volume aug_rot: random axis-aligned rotations/flips (48 total)."""
+
+    def _cfg(self, zarr2_volume, patch, res, aug_rot=True, output_axes="lzyx", labels=False):
+        vol = {"name": "v", "path": str(zarr2_volume), "image_key": "raw", "aug_rot": aug_rot}
+        if labels:
+            vol["label_key"] = "labels/seg"
+        return MiaoConfig(
+            volumes=[vol],
+            resolutions=res,
+            output_axes=output_axes,
+            patch_size=patch,
+            samples_per_epoch=50,
+        )
+
+    def test_default_false(self, zarr2_volume: Path):
+        cfg = MiaoConfig(
+            volumes=[{"name": "v", "path": str(zarr2_volume), "image_key": "raw"}],
+            resolutions=RES_1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+        )
+        assert cfg.volumes[0].aug_rot is False
+
+    def test_shape_preserved(self, zarr2_volume: Path):
+        cfg = self._cfg(zarr2_volume, [8, 8, 8], RES_2)
+        ds = VolumeDataset(cfg)
+        np.random.seed(0)
+        for i in range(20):
+            assert ds[i]["img"].shape == (2, 8, 8, 8)
+
+    def test_preserves_value_multiset(self, zarr2_volume: Path):
+        """A signed permutation is a bijection over a cubic patch, so the sorted voxel values
+        are invariant. Force a single center (patch == full volume) so aug is the only change."""
+        # patch 64 on the 64^3 fixture at res [1,1,1] → exactly one valid center (deterministic).
+        aug = VolumeDataset(self._cfg(zarr2_volume, [64, 64, 64], RES_1, aug_rot=True))
+        plain = VolumeDataset(self._cfg(zarr2_volume, [64, 64, 64], RES_1, aug_rot=False))
+        ref = plain[0]["img"]
+        for i in range(10):
+            np.random.seed(i)
+            out = aug[i]["img"]
+            assert out.shape == ref.shape
+            assert torch.allclose(
+                torch.sort(out.flatten()).values, torch.sort(ref.flatten()).values
+            )
+
+    def test_produces_variation(self, zarr2_volume: Path):
+        """Over many samples of a fixed patch, more than one distinct orientation appears."""
+        aug = VolumeDataset(self._cfg(zarr2_volume, [64, 64, 64], RES_1, aug_rot=True))
+        np.random.seed(0)
+        seen = {aug[i]["img"].numpy().tobytes() for i in range(30)}
+        assert len(seen) > 1
+
+    def test_image_and_label_share_transform(self, tmp_path: Path):
+        """Image and label get the same transform. Build a volume whose label is a spatial
+        gradient so the orientation is recoverable, and check img/label stay aligned."""
+        import json
+
+        import zarr
+        from zarr.storage import LocalStore
+
+        zpath = tmp_path / "grad.zarr"
+        store = LocalStore(str(zpath))
+        root = zarr.open_group(store, mode="a", zarr_format=2)
+        axes = [{"name": n, "type": "space", "unit": "micrometer"} for n in "zyx"]
+        # Distinct value at every voxel so the orientation is unambiguous.
+        data = np.arange(8 * 8 * 8, dtype=np.float32).reshape(8, 8, 8)
+        for key, dtype, arr in [("raw", "float32", data), ("seg", "uint32", data.astype("uint32"))]:
+            grp = root.create_group(key)
+            a = grp.create_array("0", shape=(8, 8, 8), chunks=(8, 8, 8), dtype=dtype, overwrite=True)
+            a[:] = arr
+            zattrs = zpath / key / ".zattrs"
+            zattrs.write_text(json.dumps({"multiscales": [{
+                "version": "0.4", "axes": axes,
+                "datasets": [{"path": "0", "coordinateTransformations": [
+                    {"type": "scale", "scale": [1.0, 1.0, 1.0]}]}],
+            }]}))
+
+        cfg = MiaoConfig(
+            volumes=[{
+                "name": "v", "path": str(zpath), "image_key": "raw",
+                "label_key": "seg", "aug_rot": True, "normalize": False,
+            }],
+            resolutions=RES_1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            samples_per_epoch=20,
+        )
+        ds = VolumeDataset(cfg)
+        for i in range(20):
+            np.random.seed(i)
+            s = ds[i]
+            # Same transform on both → image (float) equals label (as float) elementwise.
+            assert torch.equal(s["img"][0], s["label"][0].to(torch.float32))
+
+    def test_anisotropic_resolution_raises(self, zarr2_volume: Path):
+        """Fixed anisotropic output resolution → error at read time."""
+        cfg = self._cfg(zarr2_volume, [8, 8, 8], [[1, 1, 2]])
+        ds = VolumeDataset(cfg)
+        with pytest.raises(ValueError, match="isotropic output resolution"):
+            ds[0]
+
+    def test_anisotropic_sampling_raises(self, zarr2_volume: Path):
+        """Per-axis resolution sampling can draw anisotropic resolutions → error at read time."""
+        vol = {"name": "v", "path": str(zarr2_volume), "image_key": "raw", "aug_rot": True}
+        cfg = MiaoConfig(
+            volumes=[vol],
+            resolution_sampling={"ranges": [[[1, 1, 1], [2, 4, 4]]]},
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            samples_per_epoch=10,
+        )
+        ds = VolumeDataset(cfg)
+        np.random.seed(0)
+        with pytest.raises(ValueError, match="isotropic output resolution"):
+            for i in range(20):
+                ds[i]
+
+    def test_isotropic_sampling_ok(self, zarr2_volume: Path):
+        vol = {"name": "v", "path": str(zarr2_volume), "image_key": "raw", "aug_rot": True}
+        cfg = MiaoConfig(
+            volumes=[vol],
+            resolution_sampling={"ranges": [[[1], [4]]], "n_scales": 2},
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            samples_per_epoch=10,
+        )
+        ds = VolumeDataset(cfg)
+        np.random.seed(0)
+        for i in range(10):
+            assert ds[i]["img"].shape == (2, 8, 8, 8)
+
+    def test_non_cubic_patch_rejected(self, zarr2_volume: Path):
+        with pytest.raises(ValueError, match="cubic patch_size"):
+            self._cfg(zarr2_volume, [8, 8, 4], RES_1)
+
+    def test_missing_spatial_axis_rejected(self, zarr2_volume: Path):
+        with pytest.raises(ValueError, match="contain all of x, y, z"):
+            MiaoConfig(
+                volumes=[{
+                    "name": "v", "path": str(zarr2_volume),
+                    "image_key": "raw", "aug_rot": True,
+                }],
+                resolutions=[[1, 1]],
+                output_axes="lyx",
+                patch_size=[8, 8],
+            )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -378,6 +378,81 @@ class TestVolumeDataset:
         sample = ds[0]
         assert torch.allclose(sample["img"], torch.full_like(sample["img"], expected))
 
+    def test_patch_normalize_single_scale(self, zarr2_volume: Path):
+        """Single scale: the returned sample has zero mean and unit standard deviation."""
+        cfg = MiaoConfig(
+            volumes=[
+                {
+                    "name": "test",
+                    "path": str(zarr2_volume),
+                    "image_key": "raw",
+                    "patch_normalize": True,
+                }
+            ],
+            resolutions=RES_1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            samples_per_epoch=1,
+        )
+        ds = VolumeDataset(cfg)
+        img = ds[0]["img"]
+        assert img.mean().abs() < 1e-5
+        assert abs(img.std().item() - 1.0) < 1e-5
+
+    def test_patch_normalize_multi_scale_uses_coarsest(self, zarr2_volume: Path):
+        """Multi-scale: every scale is normalized by the coarsest crop's mean/std."""
+
+        def sample(patch_normalize: bool) -> torch.Tensor:
+            cfg = MiaoConfig(
+                volumes=[
+                    {
+                        "name": "test",
+                        "path": str(zarr2_volume),
+                        "image_key": "raw",
+                        "patch_normalize": patch_normalize,
+                    }
+                ],
+                resolutions=RES_3,
+                output_axes="lzyx",
+                patch_size=[8, 8, 8],
+                sampling="sequential",
+            )
+            return VolumeDataset(cfg)[0]["img"]
+
+        raw = sample(False)
+        normed = sample(True)
+
+        coarsest = raw[-1]
+        expected = (raw - coarsest.mean()) / coarsest.std()
+        assert torch.allclose(normed, expected, atol=1e-5)
+
+        # Only the reference scale is exactly standardized; the finer ones share its statistics.
+        assert normed[-1].mean().abs() < 1e-5
+        assert abs(normed[-1].std().item() - 1.0) < 1e-5
+
+    def test_patch_normalize_constant_patch(self, zarr2_volume: Path):
+        """A zero-variance patch must not produce inf/nan."""
+        cfg = MiaoConfig(
+            volumes=[
+                {
+                    "name": "test",
+                    "path": str(zarr2_volume),
+                    "image_key": "raw",
+                    "normalize": True,
+                    "normalize_min": 0.0,
+                    "normalize_max": 1e-12,  # clips everything to the upper bound
+                    "patch_normalize": True,
+                }
+            ],
+            resolutions=RES_1,
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            samples_per_epoch=1,
+        )
+        ds = VolumeDataset(cfg)
+        img = ds[0]["img"]
+        assert torch.isfinite(img).all()
+
     # ── Random mode: grid_index is None ──────────────────────────────────────
 
     def test_random_mode_no_grid_index(self, zarr2_volume: Path):


### PR DESCRIPTION
This PR incorporates the following three changes:

- data augmentation via axis-aligned rotations/flips (x48), if aug_rot set to true.  will throw error if requested data resolution is not isotropic
- returning pixel size in expected format for scale-aware muvit
- option for patch_normalization to normalize each data sample to have zero-mean unit std.  if data sample is multi-scale, mean and std parameters are estimated from coarsest resolution (largest physical size sample), and applied to all scales
