### PR TITLE
all axes specifications in output_axes ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,10 @@ scale-conditioned model.
 
 It reports the resolutions actually used for that sample, so in **random resolution sampling**
 mode it reflects the freshly-drawn values on every `__getitem__` rather than a fixed list. The
-same values (before reordering to output axis order) are also mirrored in `meta["resolutions"]`.
+same values are also mirrored in `meta["resolutions"]` (also in `output_axes` spatial order).
+
+All spatial fields in `meta` are reported in `output_axes` spatial order: `coordinate`
+(level-0 reference voxels), `resolutions`, and, in sequential mode, `grid_index`.
 
 ### How it works
 
@@ -147,7 +150,7 @@ Each sample:
 | `volumes[].weight` | Sampling probability weight (default: equal across volumes) |
 | `volumes[].normalize` | Auto-normalize images to [0, 1] by dtype max (default: `true`). Also see `normalize_min` / `normalize_max` to set upper and lower normalization bounds|
 | `volumes[].patch_normalize` | Standardize each returned sample to zero mean / unit standard deviation, applied after `normalize` (default: `false`). With multiple scales, the statistics are taken from the coarsest-resolution (largest physical extent) crop and applied to every scale |
-| `volumes[].bounding_box` | Optional `[[min, max], ...]` per spatial axis (finest-level voxels, storage axis order). Every window's read extent — at every scale, including coarser `sample_windows` patches — is kept strictly inside the box. Must be at least as large as the coarsest window, or dataset construction raises. |
+| `volumes[].bounding_box` | Optional `[[min, max], ...]` per spatial axis (finest-level voxels, `output_axes` spatial order — same order as `patch_size`). Every window's read extent — at every scale, including coarser `sample_windows` patches — is kept strictly inside the box. Must be at least as large as the coarsest window, or dataset construction raises. |
 | `volumes[].aug_rot` | If `true` (default: `false`), apply a random axis-aligned rotation/flip to each returned sample — one of the 48 symmetries of the cube. Requires isotropic output. See "Axis-aligned rotation/flip augmentation (`aug_rot`)" below. |
 | `resolutions` | List of desired output resolutions, one tuple per scale. Each tuple is the output voxel size per spatial axis (physical units), in `output_axes` spatial order. The number of scales (the `l` dimension) is `len(resolutions)`. Mutually exclusive with `resolution_sampling` |
 | `resolution_sampling` | Draw resolutions randomly per sample instead of a fixed list: `{strategy, ranges, n_scales, sort}`. See "Random resolution sampling" above. Mutually exclusive with `resolutions` |
@@ -186,6 +189,7 @@ for batch in loader:
     pixel_size = batch["pixel_size"]   # (B, L, Nd_spatial) output voxel size per level
     meta = batch["meta"]
     # meta["grid_index"]: tuple e.g. (2, 0, 3) = position in the grid per axis
+    #   (output_axes spatial order, matching the img/label tensor axes)
     # use grid_index to stitch patch predictions back into a full-volume output
 ```
 
@@ -195,7 +199,7 @@ In sequential mode the grid tiles the volume at the **first scale's** target res
 stride is one output patch (minus `overlap`) worth of physical extent. This gives full
 coverage of the output volume with no gaps, even when the source data is anisotropic. Patch
 centers are reported in `meta["coordinate"]` (level-0 reference voxels) and the grid position
-in `meta["grid_index"]`.
+in `meta["grid_index"]`, both in `output_axes` spatial order.
 
 ### Multi-scale window sampling (`sample_windows`)
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -4,7 +4,7 @@ volumes:
     image_key: "raw"
     zarr_version: "zarr3"
     label_key: "labels/agglom_seg"
-    bounding_box: [[1197, 5561], [1457, 4773], [1132, 12109]]  # [z_min, z_max], [y_min, y_max], [x_min, x_max] (finest-level voxels, storage order). Every window's read extent stays strictly inside this box.
+    bounding_box: [[1132, 12109], [1457, 4773], [1197, 5561]]  # [x_min, x_max], [y_min, y_max], [z_min, z_max] (finest-level voxels, output_axes spatial order — like patch_size). Every window's read extent stays strictly inside this box.
     weight: 0.5
     normalize: true  # Auto-normalize images to [0, 1] by dtype max (default: `true`)
 

--- a/examples/legacy/bench_fmt_zarr2.yaml
+++ b/examples/legacy/bench_fmt_zarr2.yaml
@@ -5,7 +5,7 @@ volumes:
     zarr_version: "zarr2"
     scales: [0, 1, 2]
     label_key: "labels/agglom_seg"
-    bounding_box: [[1197, 5561], [1457, 4773], [1132, 12109]]
+    bounding_box: [[1132, 12109], [1457, 4773], [1197, 5561]]
     weight: 1.0
     normalize: true
 

--- a/examples/legacy/bench_fmt_zarr3_nosharding.yaml
+++ b/examples/legacy/bench_fmt_zarr3_nosharding.yaml
@@ -5,7 +5,7 @@ volumes:
     zarr_version: "zarr3"
     scales: [0, 1, 2]
     label_key: "labels/agglom_seg"
-    bounding_box: [[1197, 5561], [1457, 4773], [1132, 12109]]
+    bounding_box: [[1132, 12109], [1457, 4773], [1197, 5561]]
     weight: 1.0
     normalize: true
 

--- a/examples/legacy/bench_fmt_zarr3_sharded.yaml
+++ b/examples/legacy/bench_fmt_zarr3_sharded.yaml
@@ -5,7 +5,7 @@ volumes:
     zarr_version: "zarr3"
     scales: [0, 1, 2]
     label_key: "labels/agglom_seg"
-    bounding_box: [[1197, 5561], [1457, 4773], [1132, 12109]]
+    bounding_box: [[1132, 12109], [1457, 4773], [1197, 5561]]
     weight: 1.0
     normalize: true
 

--- a/examples/legacy/bench_fmt_zarr3_sharded_128chunk.yaml
+++ b/examples/legacy/bench_fmt_zarr3_sharded_128chunk.yaml
@@ -5,7 +5,7 @@ volumes:
     zarr_version: "zarr3"
     scales: [0, 1, 2]
     label_key: "labels/agglom_seg"
-    bounding_box: [[1197, 5561], [1457, 4773], [1132, 12109]]
+    bounding_box: [[1132, 12109], [1457, 4773], [1197, 5561]]
     weight: 1.0
     normalize: true
 

--- a/examples/legacy/config_iso.yaml
+++ b/examples/legacy/config_iso.yaml
@@ -5,7 +5,7 @@ volumes:
     zarr_version: "zarr2"
     scales: [0, 1, 2]
     label_key: "labels/agglom_seg"
-    bounding_box: [[1197, 5561], [1457, 4773], [1132, 12109]]
+    bounding_box: [[1132, 12109], [1457, 4773], [1197, 5561]]
     weight: 0.5
     normalize: true
 

--- a/examples/legacy/config_jiefu_only.yaml
+++ b/examples/legacy/config_jiefu_only.yaml
@@ -5,7 +5,7 @@ volumes:
     zarr_version: "zarr2"
     scales: [0, 1, 2]
     label_key: "labels/agglom_seg"
-    bounding_box: [[1197, 5561], [1457, 4773], [1132, 12109]]
+    bounding_box: [[1132, 12109], [1457, 4773], [1197, 5561]]
     weight: 1.0
     normalize: true
 

--- a/examples/legacy/config_noiso.yaml
+++ b/examples/legacy/config_noiso.yaml
@@ -5,7 +5,7 @@ volumes:
     zarr_version: "zarr2"
     scales: [0, 1, 2]
     label_key: "labels/agglom_seg"
-    bounding_box: [[1197, 5561], [1457, 4773], [1132, 12109]]
+    bounding_box: [[1132, 12109], [1457, 4773], [1197, 5561]]
     weight: 0.5
     normalize: true
 

--- a/examples/legacy/config_patch256.yaml
+++ b/examples/legacy/config_patch256.yaml
@@ -5,7 +5,7 @@ volumes:
     zarr_version: "zarr2"
     scales: [0, 1, 2]
     label_key: "labels/agglom_seg"
-    bounding_box: [[1197, 5561], [1457, 4773], [1132, 12109]]
+    bounding_box: [[1132, 12109], [1457, 4773], [1197, 5561]]
     weight: 0.5
     normalize: true
 

--- a/examples/legacy/config_patch64.yaml
+++ b/examples/legacy/config_patch64.yaml
@@ -5,7 +5,7 @@ volumes:
     zarr_version: "zarr2"
     scales: [0, 1, 2]
     label_key: "labels/agglom_seg"
-    bounding_box: [[1197, 5561], [1457, 4773], [1132, 12109]]
+    bounding_box: [[1132, 12109], [1457, 4773], [1197, 5561]]
     weight: 0.5
     normalize: true
 

--- a/src/miao/config.py
+++ b/src/miao/config.py
@@ -103,9 +103,9 @@ class VolumeConfig(BaseModel):
     # data to be anisotropic (e.g. z coarser than x/y and upsampled) as long as the requested
     # output resolution is isotropic.
     aug_rot: bool = False
-    # [[min_0, max_0], ...] in finest-scale voxels, storage axis order. Strictly contains every
-    # window's read extent (all scales, including coarser sample_windows patches), not just the
-    # patch center. Must be at least as large as the coarsest window.
+    # [[min_0, max_0], ...] in finest-scale voxels, output_axes spatial order (like patch_size).
+    # Strictly contains every window's read extent (all scales, including coarser sample_windows
+    # patches), not just the patch center. Must be at least as large as the coarsest window.
     bounding_box: Optional[list[list[int]]] = None
 
     @field_validator("weight")

--- a/src/miao/dataset.py
+++ b/src/miao/dataset.py
@@ -272,7 +272,10 @@ class VolumeInfo:
     # Valid center coordinate range (spatial dims only, in image spatial axis order, level-0 frame)
     min_center: np.ndarray
     max_center: np.ndarray
-    
+    # bounding_box reordered from the config's output_axes spatial order to image storage spatial
+    # order, shape (Nd_spatial, 2) as [lo, hi); None when no bounding_box is configured.
+    bounding_box: np.ndarray | None = None
+
     # Cached per-scale resolution (fixed-resolution mode); None when sampling per call
     scales: ScaleResolution | None = None
     # Resolution sampling spec (sampling mode); None when resolutions are fixed
@@ -319,6 +322,8 @@ class VolumeDataset(torch.utils.data.Dataset):
        "pixel_size" is (L, Nd_spatial) µm/px per level in output spatial axis
        order (matching "bbox"); in resolution-sampling mode it reflects the
        resolutions drawn for that sample.
+       Every spatial field in "meta" ("coordinate", "resolutions", and, in
+       sequential mode, "grid_index") is reported in output_axes spatial order.
 
     Tensor shapes are (1, L, *output_axes_dims) where L = number of scale levels.
     Input axes are auto-detected from OME-NGFF metadata.
@@ -491,7 +496,16 @@ class VolumeDataset(torch.utils.data.Dataset):
             )
         else:
             lbl_np_dt, lbl_torch_dt = np.dtype(np.int64), torch.int64
-            
+
+        # bounding_box is specified in output_axes spatial order; reorder it to image storage
+        # spatial order so it can be compared against storage-ordered read extents downstream.
+        bounding_box = None
+        if vol_cfg.bounding_box is not None:
+            bb_perm = compute_permutation(output_spatial, img_spatial)
+            bounding_box = np.array(
+                [vol_cfg.bounding_box[p] for p in bb_perm], dtype=np.float64
+            )
+
         # Build the static (resolution-independent) volume info first.
         vol_info = VolumeInfo(
             config=vol_cfg,
@@ -510,6 +524,7 @@ class VolumeDataset(torch.utils.data.Dataset):
             read_shape=read_shape,
             min_center=np.zeros(len(img_sp_idx), dtype=np.int64),
             max_center=np.zeros(len(img_sp_idx), dtype=np.int64),
+            bounding_box=bounding_box,
             label_np_dtype=lbl_np_dt,
             label_torch_dtype=lbl_torch_dt,
         )
@@ -622,9 +637,8 @@ class VolumeDataset(torch.utils.data.Dataset):
         min_center = np.zeros(len(img_sp_idx), dtype=np.float64)
         max_center = finest_spatial_shape.copy().astype(np.float64)
 
-        bb = None
-        if vol_info.config.bounding_box is not None:
-            bb = np.array(vol_info.config.bounding_box, dtype=np.float64)  # ref-frame [lo, hi)
+        # bounding_box (image storage spatial order, reference-frame [lo, hi)); None if unset.
+        bb = vol_info.bounding_box
 
         def _apply(rel: np.ndarray, eff: np.ndarray, sp_shape: np.ndarray) -> None:
             nonlocal min_center, max_center
@@ -971,8 +985,8 @@ class VolumeDataset(torch.utils.data.Dataset):
         sample_roi_lo: np.ndarray | None = None
         sample_roi_hi_excl: np.ndarray | None = None
         n_scales = len(scales.resolutions)
-        if self.config.sample_windows and n_scales > 1 and vol_info.config.bounding_box is not None:
-            bb = np.array(vol_info.config.bounding_box, dtype=np.float64)
+        if self.config.sample_windows and n_scales > 1 and vol_info.bounding_box is not None:
+            bb = vol_info.bounding_box  # image storage spatial order, reference-frame [lo, hi)
             sample_roi_lo = bb[:, 0]
             sample_roi_hi_excl = bb[:, 1]
 
@@ -1217,6 +1231,20 @@ class VolumeDataset(torch.utils.data.Dataset):
         )
         pixel_size_tensor = torch.from_numpy(pixel_size_arr).float()
 
+        # `center`, `scales.resolutions`, and `grid_index` are all in image storage spatial order;
+        # reorder each to output_axes spatial order (via `spatial_perm`, as bbox/pixel_size do) so
+        # every spatial field in `meta` is reported in output_axes order.
+        coordinate_out = center[list(spatial_perm)].tolist()
+        resolutions_out = [
+            np.asarray(res, dtype=np.float64)[list(spatial_perm)].tolist()
+            for res in scales.resolutions
+        ]
+        grid_index_out = (
+            tuple(int(grid_index[p]) for p in spatial_perm)
+            if grid_index is not None
+            else None
+        )
+
         return {
             "img": img_tensor,
             "label": label_tensor,
@@ -1224,10 +1252,10 @@ class VolumeDataset(torch.utils.data.Dataset):
             "pixel_size": pixel_size_tensor,
             "meta": {
                 "volume": vol_info.config.name,
-                "coordinate": center.tolist(),
-                "resolutions": [r.tolist() for r in scales.resolutions],
+                "coordinate": coordinate_out,
+                "resolutions": resolutions_out,
                 "source_levels": scales.chosen_levels,
                 # grid_index only present in sequential mode; None breaks DataLoader collation
-                **({"grid_index": grid_index} if grid_index is not None else {}),
+                **({"grid_index": grid_index_out} if grid_index_out is not None else {}),
             },
         }

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -133,10 +133,11 @@ class TestVolumeDataset:
         # output_axes="lxzy" → (L, X, Z, Y)
         assert sample["img"].shape == (1, 6, 8, 12)
 
-        # The values must be the on-disk crop around meta["coordinate"] (storage
-        # zyx order), transposed zyx → xzy. At resolution [1,1,1] the read is
-        # level 0 with no resampling, so the match is exact.
-        center = np.array(sample["meta"]["coordinate"])
+        # meta["coordinate"] is in output_axes spatial order ("xzy"); map it back to
+        # storage (zyx) to reconstruct the on-disk crop, transposed zyx → xzy. At
+        # resolution [1,1,1] the read is level 0 with no resampling, so the match is exact.
+        coord = sample["meta"]["coordinate"]  # output order: x, z, y
+        center = np.array([coord["xzy".index(c)] for c in "zyx"])  # storage z, y, x order
         storage_shape = np.array([8, 12, 6])  # patch_size in storage (z, y, x) order
         origin = np.clip(center - storage_shape // 2, 0, 64 - storage_shape)
         raw = zarr.open_group(str(zarr2_volume), mode="r")["raw"]["0"][
@@ -990,6 +991,38 @@ class TestBoundingBox:
             },
         )
         self._assert_inside(VolumeDataset(cfg))
+
+    def test_output_axes_order(self, zarr2_volume: Path):
+        """bounding_box is given in output_axes spatial order, not storage order.
+
+        Storage is zyx; output spatial order is xyz. An asymmetric box exercises the
+        permutation: it is reordered internally to storage (zyx) and every returned
+        window (reported in output xyz order) stays inside the box as specified.
+        """
+        # output xyz order: x in [9, 55], y in [12, 48], z in [10, 50].
+        bb_xyz = [[9, 55], [12, 48], [10, 50]]
+        cfg = MiaoConfig(
+            volumes=[{
+                "name": "v", "path": str(zarr2_volume), "image_key": "raw",
+                "bounding_box": bb_xyz,
+            }],
+            output_axes="lxyz", patch_size=[8, 8, 8], resolutions=RES_3,
+            samples_per_epoch=300,
+        )
+        ds = VolumeDataset(cfg)
+
+        # Stored bounding_box is reordered to storage (zyx): [z, y, x].
+        stored = ds._volumes[0].bounding_box
+        np.testing.assert_array_equal(stored, [[10, 50], [12, 48], [9, 55]])
+
+        # Every window (bbox tensor is in output xyz order; isotropic volume so fv=1) fits.
+        fv = ds._volumes[0].finest_voxel_size
+        bb = np.array(bb_xyz, dtype=float)
+        np.random.seed(0)
+        for i in range(300):
+            bbx = ds[i]["bbox"].numpy()  # (L, 2, 3), output spatial = xyz
+            assert np.all(bbx[:, 0, :] / fv >= bb[:, 0] - 1e-6)
+            assert np.all(bbx[:, 1, :] / fv <= bb[:, 1] + 1e-6)
 
     def test_too_small_box_raises(self, zarr2_volume: Path):
         """A box smaller than the coarsest window raises a clear error at dataset build."""


### PR DESCRIPTION
made code consistent in terms of expecting and returning axes in output_axes ordering; in particular this is a breaking change for volumes[].bounding_vox, and the fields within meta, changing from storage ordering to output_axes ordering