### PR TITLE
Fix: image/label axis order mismatch check

### DIFF
--- a/src/miao/dataset.py
+++ b/src/miao/dataset.py
@@ -462,16 +462,12 @@ class VolumeDataset(torch.utils.data.Dataset):
             lbl_spatial = spatial_axes(lbl_axes)
             lbl_sp_idx = spatial_indices(lbl_axes)
 
-            # Reads are addressed in each array's own on-disk axis order, and the label read
-            # coordinates are derived from image-order quantities (patch centre, voxel-size
-            # ratios, read extents). If the two groups declare their spatial axes in different
-            # orders those quantities silently refer to different axes, and labels come back
-            # transposed relative to the image — with the correct shape and dtype, so nothing
-            # downstream can detect it. OME-NGFF permits per-group axis order, so reject the
-            # case explicitly rather than returning corrupt data.
+            # Label read coords are derived from image-order quantities, so a differing
+            # spatial axis order silently transposes the label crop (same shape/dtype,
+            # undetectable downstream). Reject it explicitly instead.
             #
-            # Only SPATIAL order is compared: a channel axis on one side and not the other
-            # (e.g. image "cxyz", label "xyz") is common and handled correctly.
+            # Only spatial order is compared — a channel axis present on one side but not
+            # the other (e.g. image "cxyz", label "xyz") is fine.
             if lbl_spatial != img_spatial:
                 raise ValueError(
                     f"Volume {vol_cfg.name!r}: label spatial axes {lbl_spatial!r} "

--- a/src/miao/dataset.py
+++ b/src/miao/dataset.py
@@ -462,6 +462,28 @@ class VolumeDataset(torch.utils.data.Dataset):
             lbl_spatial = spatial_axes(lbl_axes)
             lbl_sp_idx = spatial_indices(lbl_axes)
 
+            # Reads are addressed in each array's own on-disk axis order, and the label read
+            # coordinates are derived from image-order quantities (patch centre, voxel-size
+            # ratios, read extents). If the two groups declare their spatial axes in different
+            # orders those quantities silently refer to different axes, and labels come back
+            # transposed relative to the image — with the correct shape and dtype, so nothing
+            # downstream can detect it. OME-NGFF permits per-group axis order, so reject the
+            # case explicitly rather than returning corrupt data.
+            #
+            # Only SPATIAL order is compared: a channel axis on one side and not the other
+            # (e.g. image "cxyz", label "xyz") is common and handled correctly.
+            if lbl_spatial != img_spatial:
+                raise ValueError(
+                    f"Volume {vol_cfg.name!r}: label spatial axes {lbl_spatial!r} "
+                    f"(from {lbl_axes!r}) do not match image spatial axes {img_spatial!r} "
+                    f"(from {img_axes!r}). Reading labels whose axis order differs from the "
+                    "image is not supported — the label crop would be transposed relative to "
+                    "the image with no other symptom. Point label_key at a label group written "
+                    f"in {img_spatial!r} order, or rewrite this one transposed on disk.\n"
+                    f"  image_key={vol_cfg.image_key!r}\n"
+                    f"  label_key={vol_cfg.label_key!r}"
+                )
+
         # Output patch size in image spatial axis order (interpolation target for every scale)
         read_shape = map_patch_size_to_input(
             self.config.patch_size, img_spatial, output_spatial

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1334,3 +1334,120 @@ class TestAugRot:
                 output_axes="lyx",
                 patch_size=[8, 8],
             )
+
+
+def _build_axes_volume(root: Path, img_axes: str, lbl_axes: str, n: int = 16) -> Path:
+    """A minimal container whose image and label groups declare the given axis orders.
+
+    Both hold the same physical data (values encode the physical voxel coordinate) written in
+    each group's own on-disk order, with isotropic unit voxels.
+    """
+    import json
+
+    import zarr
+    from zarr.storage import LocalStore
+
+    zz, yy, xx = np.meshgrid(np.arange(n), np.arange(n), np.arange(n), indexing="ij")
+    val_zyx = (zz * 10000 + yy * 100 + xx).astype(np.float32)
+
+    grp_root = zarr.open_group(LocalStore(str(root)), mode="a", zarr_format=2)
+    for key, axes_str, dtype in [("raw", img_axes, "float32"), ("seg", lbl_axes, "uint32")]:
+        spatial = "".join(c for c in axes_str if c in "xyz")
+        data = np.transpose(val_zyx, ["zyx".index(c) for c in spatial]).astype(dtype)
+        if "c" in axes_str:  # singleton channel at the position declared in axes_str
+            data = np.expand_dims(data, axis=axes_str.index("c"))
+        g = grp_root.create_group(key)
+        a = g.create_array("0", shape=data.shape, chunks=data.shape, dtype=dtype, overwrite=True)
+        a[:] = data
+        axes = [
+            {"name": c, "type": ("channel" if c == "c" else "space")}
+            | ({} if c == "c" else {"unit": "micrometer"})
+            for c in axes_str
+        ]
+        (root / key / ".zattrs").write_text(json.dumps({"multiscales": [{
+            "version": "0.4", "axes": axes,
+            "datasets": [{"path": "0", "coordinateTransformations": [
+                {"type": "scale", "scale": [1.0] * len(axes_str)}]}],
+        }]}))
+    return root
+
+
+class TestLabelAxisOrderValidation:
+    """A label group whose SPATIAL axis order differs from the image's must be rejected.
+
+    Reads are addressed in each array's own on-disk order while label read coordinates are
+    derived from image-order quantities, so a mismatch silently returns transposed labels — with
+    the correct shape and dtype, hence undetectable downstream. Real data exhibits this (an
+    OME-NGFF container may store `raw` as xyz and a label group as zyx), so it is rejected up
+    front instead.
+    """
+
+    def _cfg(self, path: Path) -> MiaoConfig:
+        return MiaoConfig(
+            volumes=[{"name": "v", "path": str(path), "image_key": "raw", "label_key": "seg"}],
+            resolutions=RES_1, output_axes="lzyx", patch_size=[4, 4, 4], samples_per_epoch=2,
+        )
+
+    def test_matching_axes_accepted(self, tmp_path: Path):
+        p = _build_axes_volume(tmp_path / "ok.zarr", "zyx", "zyx")
+        ds = VolumeDataset(self._cfg(p))
+        assert ds[0]["label"].shape == (1, 4, 4, 4)
+
+    def test_reversed_label_axes_rejected(self, tmp_path: Path):
+        p = _build_axes_volume(tmp_path / "rev.zarr", "zyx", "xyz")
+        with pytest.raises(ValueError, match="do not match image spatial axes"):
+            VolumeDataset(self._cfg(p))
+
+    def test_cyclic_label_axes_rejected(self, tmp_path: Path):
+        p = _build_axes_volume(tmp_path / "cyc.zarr", "zyx", "yzx")
+        with pytest.raises(ValueError, match="do not match image spatial axes"):
+            VolumeDataset(self._cfg(p))
+
+    def test_error_names_both_keys_and_orders(self, tmp_path: Path):
+        """The message has to be actionable — which volume, which keys, which orders."""
+        p = _build_axes_volume(tmp_path / "msg.zarr", "zyx", "xyz")
+        with pytest.raises(ValueError) as exc:
+            VolumeDataset(self._cfg(p))
+        msg = str(exc.value)
+        for expected in ["'v'", "'zyx'", "'xyz'", "'raw'", "'seg'"]:
+            assert expected in msg, f"{expected} missing from error:\n{msg}"
+
+    def test_channel_only_difference_accepted(self, tmp_path: Path):
+        """image 'cxyz' vs label 'xyz' is a channel-presence difference, not a spatial-order
+        one — common in real data (all the nisb/* datasets) and handled correctly."""
+        p = _build_axes_volume(tmp_path / "chan.zarr", "cxyz", "xyz")
+        cfg = MiaoConfig(
+            volumes=[{"name": "v", "path": str(p), "image_key": "raw", "label_key": "seg"}],
+            resolutions=RES_1, output_axes="lzyx", patch_size=[4, 4, 4], samples_per_epoch=2,
+        )
+        ds = VolumeDataset(cfg)
+        assert ds[0]["label"].shape == (1, 4, 4, 4)
+
+    def test_channel_on_label_only_accepted(self, tmp_path: Path):
+        p = _build_axes_volume(tmp_path / "chan2.zarr", "zyx", "zyxc")
+        ds = VolumeDataset(self._cfg(p))
+        assert ds[0]["label"].shape == (1, 4, 4, 4)
+
+    def test_no_label_key_unaffected(self, tmp_path: Path):
+        """Volumes without labels never hit the check."""
+        p = _build_axes_volume(tmp_path / "nolbl.zarr", "zyx", "xyz")
+        cfg = MiaoConfig(
+            volumes=[{"name": "v", "path": str(p), "image_key": "raw"}],
+            resolutions=RES_1, output_axes="lzyx", patch_size=[4, 4, 4], samples_per_epoch=2,
+        )
+        ds = VolumeDataset(cfg)
+        assert ds[0]["label"].numel() == 0
+
+    def test_rejected_regardless_of_output_axes(self, tmp_path: Path):
+        """output_axes standardizes the returned tensor, not the read path — so it cannot
+        rescue a storage-order mismatch, whichever order is requested."""
+        p = _build_axes_volume(tmp_path / "out.zarr", "zyx", "xyz")
+        for out_axes in ("lzyx", "lxyz", "xyzl"):
+            cfg = MiaoConfig(
+                volumes=[{"name": "v", "path": str(p), "image_key": "raw",
+                          "label_key": "seg"}],
+                resolutions=RES_1, output_axes=out_axes, patch_size=[4, 4, 4],
+                samples_per_epoch=2,
+            )
+            with pytest.raises(ValueError, match="do not match image spatial axes"):
+                VolumeDataset(cfg)


### PR DESCRIPTION
This PR fixes https://github.com/AI-HHMI/miao/issues/18. Briefly, the code currently mixes the use of image and label coordinate frames at various places, _e.g._ :

https://github.com/AI-HHMI/miao/blob/ce625af929a7de49e85cf7b1f06d6aa8b20f2400/src/miao/dataset.py#L610 

or:

https://github.com/AI-HHMI/miao/blob/ce625af929a7de49e85cf7b1f06d6aa8b20f2400/src/miao/dataset.py#L1075

or:

https://github.com/AI-HHMI/miao/blob/ce625af929a7de49e85cf7b1f06d6aa8b20f2400/src/miao/dataset.py#L1158

where `target_size` is the image-order read shape.

This is fine when the image and the label have the same axis order, but leads to silent failures (with incorrect results) when they do not. This is never explicitly checked in the code. This PR adds that explicit check to `VolumeDataset._resolve_volume()`. New tests are also added to `test_dataset.py` with this PR to cover image/label axis order validation checks.