### PR TITLE
Setting expansion factor in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,21 @@ volumes:
     image_key: "raw"
     zarr_version: "zarr2"      # or "zarr3" (default: "zarr2")
     label_key: "labels/seg"    # optional
-    weight: 0.7                # optional
+    weight: 0.5                # optional
 
   - name: "membrane"
     path: "/data/sample_B.zarr"
     image_key: "predictions"
     zarr_version: "zarr3"
+    weight: 0.2
+
+  - name: "expanded"
+    path: "/data/expanded.zarr"
+    image_key: "raw"
+    exp_factor: 4.0            # optional, default: 1.0 — see Effective voxel sizes
     weight: 0.3
 
-resolutions: [[8, 8, 8], [16, 16, 16], [32, 32, 32]]  # output voxel size per scale
+resolutions: [[8, 8, 8], [16, 16, 16], [32, 32, 32]]  # effective output voxel size per scale
 output_axes: "lcxyz"            # layer, channels, X, Y, Z. Shuffle as you please!!!
 patch_size: [64, 64, 64]
 samples_per_epoch: 1000
@@ -60,7 +66,7 @@ Runnable notebooks live in [`examples/`](examples/).
 | `img` | `(B, L, X, Y, Z)`, or `(B, L, C, X, Y, Z)` with a channel axis | Image patch per scale level |
 | `label` | `(B, L, X, Y, Z)`, empty without a `label_key` | Label patch per scale level |
 | `bbox` | `(B, L, 2, Nd_spatial)` | Patch extent per level, world or crop-relative (see `bbox_mode`) |
-| `pixel_size` | `(B, L, Nd_spatial)` | Physical output voxel size per level |
+| `pixel_size` | `(B, L, Nd_spatial)` | Effective physical output voxel size per level |
 | `meta` | dict | `name`, `coordinate`, `resolutions` (mirroring `pixel_size`), source pyramid levels, plus `grid_index` in sequential mode |
 
 Spatial axes follow `output_axes` throughout. `pixel_size` sits at the top level rather than inside `meta` so default collate stacks it cleanly,
@@ -74,14 +80,27 @@ OME `coordinateTransformations` unit (e.g. nanometers) — never by pyramid leve
 `resolutions` list therefore serves volumes with wildly different pyramid layouts, and any volume
 can override it with its own.
 
+### Effective voxel sizes
+
+**Every voxel size and resolution in this README is an *effective* voxel size: the size of one
+voxel in the specimen, not in the microscope.** For a volume with `exp_factor: F`, the effective
+voxel size is the stored `coordinateTransformations` scale divided by `F` — a 4× expanded sample
+imaged at 200 nm holds 50 nm of biology per voxel. `exp_factor` defaults to `1.0`, so for
+unexpanded data the stored and effective sizes are identical.
+
+Level selection, read extents, `pixel_size`, and `meta["resolutions"]` are all in effective units,
+which is what lets one `resolutions` list mix expanded and unexpanded volumes correctly.
+`bounding_box` and `meta["coordinate"]` are level-0 voxel *indices*, not physical sizes, so
+`exp_factor` does not affect them.
+
 Per sample, miao:
 
 1. draws a volume by `weight`, then a random coordinate in its finest-scale (level-0) space;
-2. for each requested resolution, picks the coarsest pyramid level whose voxel size is still ≤ the
-   target on every axis, preferring downsampling — or the finest stored level, upsampled, if the
-   target is finer than anything on disk;
-3. reads `ceil(patch_size × target_resolution / level_voxel_size)` voxels centered on that
-   coordinate and resamples them to `patch_size` — trilinear for images, nearest for labels.
+2. for each requested resolution, picks the coarsest pyramid level whose effective voxel size is
+   still ≤ the target on every axis, preferring downsampling — or the finest stored level,
+   upsampled, if the target is finer than anything on disk;
+3. reads `ceil(patch_size × target_resolution / effective_level_voxel_size)` voxels centered on
+   that coordinate and resamples them to `patch_size` — trilinear for images, nearest for labels.
 
 Every crop thus holds the same voxel count while covering a wider physical extent at coarser
 scales.
@@ -190,6 +209,7 @@ fine — e.g. coarse `z` upsampled to match — as long as the requested output 
 | `path` | Path to the OME-NGFF zarr container |
 | `image_key` | Group key within the zarr for image data |
 | `zarr_version` | `"zarr2"` or `"zarr3"` (default: `"zarr2"`) |
+| `exp_factor` | Divides the zarr's metadata voxel size to give the effective (pre-expansion) voxel size (default: `1.0`). For expansion microscopy the stored value is the microscope's; `stored / exp_factor` is the specimen's. Applies to image and labels, before level selection — see [Effective voxel sizes](#effective-voxel-sizes) |
 | `label_key` | Optional group key for labels in the same zarr |
 | `weight` | Sampling probability weight (default: equal across volumes) |
 | `resolutions` | Optional per-volume override of the global `resolutions` (same format) |

--- a/src/miao/config.py
+++ b/src/miao/config.py
@@ -82,6 +82,9 @@ class VolumeConfig(BaseModel):
     # Optional per-volume override of the global MiaoConfig.resolution_sampling.
     resolution_sampling: Optional[ResolutionSampling] = None
     zarr_version: Literal["zarr2", "zarr3"] = "zarr2"
+    # Divides the voxel sizes read from the zarr's OME coordinateTransformations. Applied to the image and label pyramids
+    # alike, before any level selection or resampling. Leave at 1.0 for unexpanded data.
+    exp_factor: float = 1.0
     label_key: Optional[str] = None
     weight: float = 1.0
     normalize: bool = True  # scale images to [0, 1]; see normalize_min / normalize_max
@@ -113,6 +116,13 @@ class VolumeConfig(BaseModel):
     def validate_weight(cls, v: float) -> float:
         if v <= 0:
             raise ValueError(f"weight must be positive, got {v}")
+        return v
+
+    @field_validator("exp_factor")
+    @classmethod
+    def validate_exp_factor(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError(f"exp_factor must be positive, got {v}")
         return v
 
     @model_validator(mode="after")

--- a/src/miao/dataset.py
+++ b/src/miao/dataset.py
@@ -374,6 +374,11 @@ class VolumeDataset(torch.utils.data.Dataset):
                 f"    image: axes={vi.img_axes!r}, shape={finest_meta.shape}, "
                 f"dtype={finest_meta.dtype}",
             ]
+            if vi.config.exp_factor != 1.0:
+                lines.append(
+                    f"    exp_factor: {vi.config.exp_factor} "
+                    "(voxel sizes below are effective, i.e. stored / exp_factor)"
+                )
             if vi.scales is not None:
                 # Fixed: target resolution -> chosen source level (voxel size, storage read shape)
                 sc = vi.scales
@@ -490,20 +495,23 @@ class VolumeDataset(torch.utils.data.Dataset):
             self.config.patch_size, img_spatial, output_spatial
         )
 
-        # Reference frame: finest pyramid level (index 0) absolute spatial voxel size.
-        finest_spatial_factors = np.array(
-            image_meta.scales[0].scale_factors, dtype=np.float64
-        )[img_sp_idx]
+        # exp_factor converts the stored (microscope) voxel size to the effective (specimen) one.
+        exp = vol_cfg.exp_factor
 
-        # Per-level absolute spatial voxel sizes (for level selection)
+        # Reference frame: finest pyramid level (index 0) absolute effective spatial voxel size.
+        finest_spatial_factors = (
+            np.array(image_meta.scales[0].scale_factors, dtype=np.float64)[img_sp_idx] / exp
+        )
+
+        # Per-level absolute effective spatial voxel sizes (for level selection)
         img_level_voxels: dict[int, np.ndarray] = {
-            lvl: np.array(m.scale_factors, dtype=np.float64)[img_sp_idx]
+            lvl: np.array(m.scale_factors, dtype=np.float64)[img_sp_idx] / exp
             for lvl, m in image_meta.scales.items()
         }
         lbl_level_voxels: dict[int, np.ndarray] | None = None
         if label_meta is not None and lbl_sp_idx is not None:
             lbl_level_voxels = {
-                lvl: np.array(m.scale_factors, dtype=np.float64)[lbl_sp_idx]
+                lvl: np.array(m.scale_factors, dtype=np.float64)[lbl_sp_idx] / exp
                 for lvl, m in label_meta.scales.items()
             }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,7 @@ class TestVolumeConfig:
         )
         assert v.weight == 1.0
         assert v.label_key is None
+        assert v.exp_factor == 1.0
 
     def test_negative_weight(self):
         with pytest.raises(ValueError, match="positive"):
@@ -34,6 +35,16 @@ class TestVolumeConfig:
                 path="/data/test.zarr",
                 image_key="raw",
                 weight=-1.0,
+            )
+
+    @pytest.mark.parametrize("bad", [0.0, -4.0])
+    def test_non_positive_exp_factor(self, bad):
+        with pytest.raises(ValueError, match="exp_factor must be positive"):
+            VolumeConfig(
+                name="raw",
+                path="/data/test.zarr",
+                image_key="raw",
+                exp_factor=bad,
             )
 
     def test_normalize_range_both_required(self):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1044,6 +1044,86 @@ class TestBoundingBox:
             VolumeDataset(cfg)
 
             
+class TestExpFactor:
+    """exp_factor divides metadata voxel sizes, so targets are effective (pre-expansion) units.
+
+    The 64^3 fixture stores level voxel sizes [1,1,1], [2,2,2], [4,4,4]; with exp_factor=4 the
+    effective sizes are [0.25,...], [0.5,...], [1.0,...].
+    """
+
+    def _cfg(self, zarr2_volume, resolutions, exp_factor=1.0, **kw):
+        vol = {"name": "v", "path": str(zarr2_volume), "image_key": "raw"}
+        if exp_factor != 1.0:
+            vol["exp_factor"] = exp_factor
+        vol.update(kw.pop("vol", {}))
+        return MiaoConfig(
+            volumes=[vol],
+            output_axes="lzyx",
+            patch_size=[8, 8, 8],
+            samples_per_epoch=10,
+            resolutions=resolutions,
+            **kw,
+        )
+
+    def test_scales_metadata_voxel_sizes(self, zarr2_volume: Path):
+        ds = VolumeDataset(self._cfg(zarr2_volume, [[0.5, 0.5, 0.5]], exp_factor=4.0))
+        vi = ds._volumes[0]
+        assert np.allclose(vi.finest_voxel_size, [0.25, 0.25, 0.25])
+        assert np.allclose(vi.img_level_voxels[2], [1.0, 1.0, 1.0])
+
+    def test_selects_coarser_level_than_without(self, zarr2_volume: Path):
+        # 0.5 is finer than every stored size, so without exp_factor it falls back to level 0;
+        # with exp_factor=4 it matches the effective size of level 1 exactly.
+        plain = VolumeDataset(self._cfg(zarr2_volume, [[0.5, 0.5, 0.5]]))
+        assert plain._volumes[0].scales.chosen_levels == [0]
+
+        ds = VolumeDataset(self._cfg(zarr2_volume, [[0.5, 0.5, 0.5]], exp_factor=4.0))
+        scales = ds._volumes[0].scales
+        assert scales.chosen_levels == [1]
+        # target == effective level voxel size, so no resampling: read == patch_size
+        assert scales.read_shapes[0].tolist() == [8, 8, 8]
+
+    def test_equivalent_to_scaled_resolutions(self, zarr2_volume: Path):
+        """exp_factor=F at target R/F must behave exactly like exp_factor=1 at target R."""
+        res = [[1, 1, 1], [2, 2, 2], [4, 4, 4]]
+        scaled = [[r / 4.0 for r in lvl] for lvl in res]
+        plain = VolumeDataset(self._cfg(zarr2_volume, res))._volumes[0]
+        exp = VolumeDataset(self._cfg(zarr2_volume, scaled, exp_factor=4.0))._volumes[0]
+
+        assert exp.scales.chosen_levels == plain.scales.chosen_levels
+        for a, b in zip(exp.scales.read_shapes, plain.scales.read_shapes):
+            assert a.tolist() == b.tolist()
+        for a, b in zip(exp.scales.relative_scale_factors, plain.scales.relative_scale_factors):
+            assert np.allclose(a, b)
+        # Center bounds live in level-0 voxels, so they are identical too.
+        assert exp.min_center.tolist() == plain.min_center.tolist()
+        assert exp.max_center.tolist() == plain.max_center.tolist()
+
+    def test_labels_use_same_factor(self, zarr2_volume: Path):
+        cfg = self._cfg(
+            zarr2_volume,
+            [[0.25, 0.25, 0.25], [0.5, 0.5, 0.5]],
+            exp_factor=4.0,
+            vol={"label_key": "labels/seg"},
+        )
+        scales = VolumeDataset(cfg)._volumes[0].scales
+        assert scales.chosen_levels == [0, 1]
+        assert scales.label_chosen_levels == scales.chosen_levels
+
+    def test_reported_units_are_effective(self, zarr2_volume: Path):
+        cfg = self._cfg(zarr2_volume, [[0.5, 0.5, 0.5], [1.0, 1.0, 1.0]], exp_factor=4.0)
+        ds = VolumeDataset(cfg)
+        sample = ds[0]
+        assert np.allclose(sample["pixel_size"].numpy(), [[0.5] * 3, [1.0] * 3])
+        assert np.allclose(sample["meta"]["resolutions"], [[0.5] * 3, [1.0] * 3])
+        # coordinate stays in level-0 voxel indices, so it is bounded by the volume shape.
+        coord = np.array(sample["meta"]["coordinate"])
+        assert np.all(coord >= 0) and np.all(coord < 64)
+        # bbox is in effective physical units: extent == patch_size * pixel_size
+        bbox = sample["bbox"].numpy()  # (L, 2, 3)
+        assert np.allclose(bbox[:, 1, :] - bbox[:, 0, :], [[8 * 0.5] * 3, [8 * 1.0] * 3])
+
+
 class TestChunkAlignedSampling:
     """Tests for chunk_aligned=True random sampling."""
 


### PR DESCRIPTION
For each volume, the config allows setting an expansion factor which converts the post expansion voxel sizes to effective voxel sizes used for model training. Adresses #23. 