### PR TITLE
Apply Outer coordinateTransformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ voxel size is the stored `coordinateTransformations` scale divided by `F` — a 
 imaged at 200 nm holds 50 nm of biology per voxel. `exp_factor` defaults to `1.0`, so for
 unexpanded data the stored and effective sizes are identical.
 
+If the zarr's OME metadata already carries the correction as a multiscale-level (outer)
+`coordinateTransformations` scale, it is applied automatically — set `exp_factor` only for
+stores that lack that metadata, or the correction would be applied twice.
+
 Level selection, read extents, `pixel_size`, and `meta["resolutions"]` are all in effective units,
 which is what lets one `resolutions` list mix expanded and unexpanded volumes correctly.
 `bounding_box` and `meta["coordinate"]` are level-0 voxel *indices*, not physical sizes, so
@@ -208,7 +212,7 @@ fine — e.g. coarse `z` upsampled to match — as long as the requested output 
 | `path` | Path to the OME-NGFF zarr container |
 | `image_key` | Group key within the zarr for image data |
 | `zarr_version` | `"zarr2"` or `"zarr3"` (default: `"zarr2"`) |
-| `exp_factor` | Divides the zarr's metadata voxel size to give the effective (pre-expansion) voxel size (default: `1.0`). For expansion microscopy the stored value is the microscope's; `stored / exp_factor` is the specimen's. Applies to image and labels, before level selection — see [Effective voxel sizes](#effective-voxel-sizes) |
+| `exp_factor` | Divides the zarr's metadata voxel size to give the effective (pre-expansion) voxel size (default: `1.0`). For expansion microscopy the stored value is the microscope's; `stored / exp_factor` is the specimen's. Applies to image and labels, before level selection. Not needed when the OME metadata already carries a multiscale-level `coordinateTransformations` scale — that is applied automatically — see [Effective voxel sizes](#effective-voxel-sizes) |
 | `label_key` | Optional group key for labels in the same zarr |
 | `weight` | Sampling probability weight (default: equal across volumes) |
 | `resolutions` | Optional per-volume override of the global `resolutions` (same format) |

--- a/src/miao/zarr_meta.py
+++ b/src/miao/zarr_meta.py
@@ -158,6 +158,13 @@ def read_ome_metadata(
     axis_names = [ax["name"] for ax in axes]
     datasets = multiscales["datasets"]
 
+    # Multiscale-level (outer) transform
+    outer_scale = [1.0] * len(axis_names)
+    for transform in multiscales.get("coordinateTransformations", []):
+        if transform["type"] == "scale":
+            outer_scale = transform["scale"]
+            break
+
     # Parse scale-level metadata
     if requested_scales is None:
         requested_scales = list(range(len(datasets)))
@@ -179,6 +186,7 @@ def read_ome_metadata(
             if transform["type"] == "scale":
                 scale_factors = transform["scale"]
                 break
+        scale_factors = [s * o for s, o in zip(scale_factors, outer_scale)]
 
         shape, chunks, dtype = _read_array_metadata(array_path, zarr_version)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,11 +20,13 @@ def _create_ome_ngff_zarr2(
     dtype: str = "float32",
     fill_value: float | None = None,
     base_scale_factors: list[float] | None = None,
+    outer_scale: list[float] | None = None,
 ) -> None:
     """Create an OME-NGFF compliant zarr2 multiscale group.
 
     Each scale level is downsampled by 2x in all dimensions.
     base_scale_factors sets the voxel size at level 0 (e.g., [5, 1, 1] for anisotropic).
+    outer_scale writes a multiscale-level coordinateTransformations scale entry.
     """
     if axes is None:
         ndim = len(base_shape)
@@ -77,13 +79,16 @@ def _create_ome_ngff_zarr2(
     # Write OME-NGFF .zattrs manually (zarr 3.x attrs API may not write to .zattrs correctly for v2)
     zattrs_path = root_path / group_key / ".zattrs"
     existing = json.loads(zattrs_path.read_text()) if zattrs_path.exists() else {}
-    existing["multiscales"] = [
-        {
-            "version": "0.4",
-            "axes": axes,
-            "datasets": datasets,
-        }
-    ]
+    multiscales: dict = {
+        "version": "0.4",
+        "axes": axes,
+        "datasets": datasets,
+    }
+    if outer_scale is not None:
+        multiscales["coordinateTransformations"] = [
+            {"type": "scale", "scale": outer_scale}
+        ]
+    existing["multiscales"] = [multiscales]
     zattrs_path.write_text(json.dumps(existing))
 
 

--- a/tests/test_zarr_meta.py
+++ b/tests/test_zarr_meta.py
@@ -57,3 +57,22 @@ class TestReadOmeMetadata:
     def test_missing_group(self, zarr2_volume: Path):
         with pytest.raises(FileNotFoundError):
             read_ome_metadata(zarr2_volume, "nonexistent", "zarr2")
+
+    def test_multiscale_level_transform(self, tmp_path: Path):
+        """A multiscale-level (outer) scale transform multiplies every level's factors."""
+        from conftest import _create_ome_ngff_zarr2
+
+        zarr_path = tmp_path / "outer_scale.zarr"
+        _create_ome_ngff_zarr2(
+            zarr_path,
+            group_key="raw",
+            base_shape=(64, 64, 64),
+            num_scales=3,
+            base_scale_factors=[4.0, 2.0, 2.0],
+            outer_scale=[0.5, 0.5, 0.5],
+        )
+
+        meta = read_ome_metadata(zarr_path, "raw", "zarr2")
+        assert meta.scales[0].scale_factors == [2.0, 1.0, 1.0]
+        assert meta.scales[1].scale_factors == [4.0, 2.0, 2.0]
+        assert meta.scales[2].scale_factors == [8.0, 4.0, 4.0]


### PR DESCRIPTION
OME-Zarr volumes can store an outer (multiscale-level) `coordinateTransformations` scale, e.g. an expansion-factor correction. This PR applies that transform when reading metadata, composing it with each level's per-dataset scale. If the expansion factor is stored this way, exp_factor no longer needs to be set in config.yaml (it remains available for stores without this metadata — setting both would double-apply the correction). Follow-up to #25.