### PR TITLE
add size-based volume sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ which is what lets one `resolutions` list mix expanded and unexpanded volumes co
 
 Per sample, miao:
 
-1. draws a volume by `weight`, then a random coordinate in its finest-scale (level-0) space;
+1. draws a volume with probability ∝ `weight * size ** size_weighting_exponent`, then a random
+   coordinate in its finest-scale (level-0) space;
 2. for each requested resolution, picks the coarsest pyramid level whose effective voxel size is
    still ≤ the target on every axis, preferring downsampling — or the finest stored level,
    upsampled, if the target is finer than anything on disk;
@@ -159,7 +160,33 @@ for batch in loader:
 
 The grid tiles the volume at the **first scale's** target resolution, striding one output patch
 minus `overlap` worth of physical extent. Coverage is gap-free even on anisotropic source data.
-`samples_per_epoch` and `weight` are ignored here, and volumes are exhausted in order.
+`samples_per_epoch`, `weight` and `size_weighting_exponent` are ignored here, and volumes are
+exhausted in order. The grid already visits each volume in proportion to its sampleable extent.
+
+### Size-weighted volume sampling
+
+In `random` mode each sample picks a volume first. By default that draw is uniform, so a 512³
+ground-truth crop is chosen as often as a whole brain, which biases training toward small
+volumes. `size_weighting_exponent` tempers the draw by how much data each volume actually holds:
+
+```yaml
+size_weighting_exponent: 0.3   # p ∝ weight * size ** size_weighting_exponent
+```
+
+`size` is the number of distinct stored voxels the sampler can reach, measured on the finest
+pyramid level any configured scale reads. It is not the raw array size: it accounts for the patch
+window, `bounding_box`, and the pyramid level actually used, so a crop that admits only one patch
+center scores one patch window rather than its whole array. It is reported per volume in the
+dataset summary, alongside the resulting probability.
+
+| `size_weighting_exponent` | effect |
+| --- | --- |
+| `0.0` (default) | size ignored; probabilities come from `weight` alone |
+| `0.3` – `0.5` | tempered; the usual choice for a corpus spanning orders of magnitude |
+| `1.0` | exactly proportional to reachable content; the largest volumes dominate |
+
+`weight` still applies and multiplies the size term, so per-volume overrides keep working. At the
+default the probabilities are bit-identical to weight-only sampling.
 
 ### Multi-scale windows (`sample_windows`)
 
@@ -253,7 +280,7 @@ behavior.
 | `zarr_version` | `"zarr2"` or `"zarr3"` (default: `"zarr2"`) |
 | `exp_factor` | Divides the zarr's metadata voxel size to give the effective (pre-expansion) voxel size (default: `1.0`). For expansion microscopy the stored value is the microscope's; `stored / exp_factor` is the specimen's. Applies to image and labels, before level selection. Not needed when the OME metadata already carries a multiscale-level `coordinateTransformations` scale — that is applied automatically — see [Effective voxel sizes](#effective-voxel-sizes) |
 | `label_key` | Optional group key for labels in the same zarr |
-| `weight` | Sampling probability weight (default: equal across volumes) |
+| `weight` | Sampling probability weight (default: equal across volumes). Multiplies the size term, so `p ∝ weight * size ** size_weighting_exponent` — see [Size-weighted volume sampling](#size-weighted-volume-sampling) |
 | `resolutions` | Optional per-volume override of the global `resolutions` (same format) |
 | `normalize` | Scale images to [0, 1] by dtype max (default: `true`); `normalize_min` / `normalize_max` set the bounds explicitly |
 | `patch_normalize` | Standardize each sample to zero mean / unit variance after `normalize` (default: `false`). Multi-scale: statistics come from the coarsest crop and apply to all scales |
@@ -272,6 +299,7 @@ behavior.
 | `cache_bytes` | TensorStore cache size in bytes (default: 1 GB) |
 | `bbox_mode` | `"absolute"` world coords (default) or `"relative"` to the finest-level crop origin |
 | `sampling` | `"random"` (default) or `"sequential"` — see [Sampling](#sampling) |
+| `size_weighting_exponent` | Weight volumes by how much data they hold (default: `0.0`, off) — see [Size-weighted volume sampling](#size-weighted-volume-sampling) |
 | `overlap` | Patch overlap in voxels, sequential mode only (default: `0`). Integer or per-axis list |
 | `sample_windows` | Randomize each coarser scale's patch origin (default: `false`) — see [above](#multi-scale-windows-sample_windows) |
 

--- a/src/miao/config.py
+++ b/src/miao/config.py
@@ -68,6 +68,14 @@ class ResolutionSampling(BaseModel):
             out = [max(out[i], hi_axes[i]) for i in range(n_axes)]
         return out
 
+    def min_resolution(self, n_axes: int) -> list[float]:
+        """Per-axis finest (smallest) lower bound across all ranges (output spatial order)."""
+        out = [float("inf")] * n_axes
+        for lo, _hi in self.ranges:
+            lo_axes = lo * n_axes if len(lo) == 1 else lo
+            out = [min(out[i], lo_axes[i]) for i in range(n_axes)]
+        return out
+
 
 class VolumeConfig(BaseModel):
     """Configuration for a single zarr volume."""
@@ -161,6 +169,15 @@ class MiaoConfig(BaseModel):
     cache_bytes: int = 1 << 30  # 1 GB
     file_io_concurrency: int = 64
     sampling: Literal["random", "sequential"] = "random"
+    # Exponent for automatic volume-size weighting in `sampling: random` mode. Volume i is drawn
+    # with probability proportional to
+    #     volumes[i].weight * size_i ** size_weighting_exponent
+    # where size_i is the number of distinct stored voxels the sampler can reach in that volume
+    # (see VolumeInfo.size). 0.0 ignores size and reproduces weight-only sampling; 1.0 is exactly
+    # proportional to reachable content; 0.3-0.5 is the usual choice for a corpus spanning several
+    # orders of magnitude in size. Ignored when sampling == "sequential", whose grid is already
+    # size-proportional.
+    size_weighting_exponent: float = 0.0
     overlap: Union[int, list[int]] = 0  # voxels; in output_axes spatial order (same as patch_size)
 
     # If True, each coarser scale's patch origin is sampled uniformly at random such that the patch
@@ -169,6 +186,13 @@ class MiaoConfig(BaseModel):
     sample_windows: bool = False
     image_dtype: str = "float32"  # output image tensor dtype: "float32", "bfloat16", or "float16"
     chunk_aligned: bool = False  # constrain random patches to stay within a single chunk
+
+    @field_validator("size_weighting_exponent")
+    @classmethod
+    def validate_size_weighting_exponent(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError(f"size_weighting_exponent must be >= 0, got {v}")
+        return v
 
     @field_validator("image_dtype")
     @classmethod

--- a/src/miao/dataset.py
+++ b/src/miao/dataset.py
@@ -280,6 +280,12 @@ class VolumeInfo:
     scales: ScaleResolution | None = None
     # Resolution sampling spec (sampling mode); None when resolutions are fixed
     sampling_spec: ResolutionSampling | None = None
+
+    # Number of distinct stored voxels the sampler can reach, counted on the finest pyramid level
+    # any configured scale reads. Unlike a raw voxel count it reflects what this volume can
+    # actually deliver: a crop that only admits one patch centre scores one patch window, not its
+    # whole array. Drives MiaoConfig.size_weighting_exponent.
+    size: float = 1.0
     
     # Smallest safe dtypes for label data (derived from on-disk dtype)
     label_np_dtype: np.dtype = np.dtype(np.int64)
@@ -344,14 +350,17 @@ class VolumeDataset(torch.utils.data.Dataset):
         self.config = config
         self.augment_fn = augment_fn
 
-        # Normalize sampling weights to probabilities
-        weights = np.array([v.weight for v in config.volumes])
-        self._probabilities = weights / weights.sum()
-
         # Read metadata and precompute sampling bounds for each volume
         self._volumes: list[VolumeInfo] = []
         for vol_cfg in config.volumes:
             self._volumes.append(self._resolve_volume(vol_cfg))
+
+        # Normalize sampling weights to probabilities. Runs after resolution because the size
+        # term needs each volume's reachable extent.
+        weights = np.array(
+            [v.config.weight * v.size**config.size_weighting_exponent for v in self._volumes]
+        )
+        self._probabilities = weights / weights.sum()
 
         # Build sequential grid before printing summary (summary reports grid size)
         self._grid: list[tuple[int, np.ndarray, tuple]] = []
@@ -374,9 +383,8 @@ class VolumeDataset(torch.utils.data.Dataset):
         print(f"VolumeDataset: {len(self._volumes)} volume(s), "
               f"{mode_str}, "
               f"patch_size={self.config.patch_size}")
-        for vi in self._volumes:
+        for vi, prob in zip(self._volumes, self._probabilities):
             finest_meta = vi.image_meta.scales[0]
-            prob = self._probabilities[self._volumes.index(vi)]
             # Get axis unit from OME-NGFF metadata
             units = [ax.get("unit", "") for ax in vi.image_meta.axes]
             unit_str = units[0] if units and all(u == units[0] for u in units if u) else ""
@@ -419,7 +427,7 @@ class VolumeDataset(torch.utils.data.Dataset):
                     f"    label: axes={vi.lbl_axes!r}, shape={lbl_meta.shape}, "
                     f"dtype={lbl_meta.dtype} -> {vi.label_np_dtype}"
                 )
-            lines.append(f"    sampling: weight={prob:.2f}, "
+            lines.append(f"    sampling: p={prob:.4g}, size={vi.size:.4g} reachable voxels, "
                          f"center_range=[{vi.min_center.tolist()}, {vi.max_center.tolist()}]")
             if self.config.chunk_aligned:
                 sp_chunks = [finest_meta.chunks[i] for i in vi.img_spatial_idx]
@@ -596,6 +604,27 @@ class VolumeDataset(torch.utils.data.Dataset):
                 f"max_center={vol_info.max_center.tolist()}). Use a finer max resolution, a "
                 f"smaller patch_size, or a larger volume."
             )
+
+        # Reachable stored voxels, measured on the finest level any scale reads. In sampling mode
+        # the centre bounds come from the coarsest resolution, but a sampled draw may read a finer
+        # level, so measure there instead — otherwise `size` is understated.
+        if sampling_spec is not None:
+            size_res = self._resolve_scales(
+                vol_info, [sampling_spec.min_resolution(len(output_spatial))]
+            )
+        else:
+            size_res = scale_res
+        finest_level = min(size_res.chosen_levels)
+        at_finest = [i for i, lv in enumerate(size_res.chosen_levels) if lv == finest_level]
+        # Several scales can resolve to one level; take the largest window so `size` does not
+        # depend on the order `resolutions` happens to be written in.
+        window = np.max([size_res.read_shapes[i] for i in at_finest], axis=0).astype(np.float64)
+        rel = size_res.relative_scale_factors[at_finest[0]]
+        level_shape = np.array(
+            image_meta.scales[finest_level].shape, dtype=np.float64
+        )[img_sp_idx]
+        reachable = (vol_info.max_center - vol_info.min_center) / rel + window
+        vol_info.size = float(np.prod(np.minimum(reachable, level_shape)))
         return vol_info
 
     def _resolve_scales(

--- a/tests/test_size_weighting.py
+++ b/tests/test_size_weighting.py
@@ -1,0 +1,185 @@
+"""Tests for MiaoConfig.size_weighting_exponent and the reachable-voxel size metric."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from conftest import _create_ome_ngff_zarr2
+
+from miao.config import MiaoConfig
+from miao.dataset import VolumeDataset
+
+
+def _volume(
+    tmp_path: Path,
+    name: str,
+    shape: tuple[int, ...],
+    *,
+    num_scales: int = 3,
+    base_scale_factors: list[float] | None = None,
+) -> dict:
+    root = tmp_path / f"{name}.zarr"
+    _create_ome_ngff_zarr2(
+        root,
+        "raw",
+        shape,
+        num_scales=num_scales,
+        base_scale_factors=base_scale_factors,
+    )
+    return {"name": name, "path": str(root), "image_key": "raw", "zarr_version": "zarr2"}
+
+
+def _config(volumes: list[dict], **kwargs) -> MiaoConfig:
+    base = {
+        "resolutions": [[1, 1, 1]],
+        "output_axes": "lzyx",
+        "patch_size": [8, 8, 8],
+    }
+    base.update(kwargs)
+    return MiaoConfig(volumes=volumes, **base)
+
+
+def _sizes(volumes: list[dict], **kwargs) -> list[float]:
+    return [v.size for v in VolumeDataset(_config(volumes, **kwargs))._volumes]
+
+
+# --- the size metric -------------------------------------------------------
+
+
+def test_size_is_reachable_voxels_not_stored_voxels(tmp_path):
+    """A 64^3 volume read with a level-2 window cannot reach all 64^3 voxels."""
+    vol = _volume(tmp_path, "v", (64, 64, 64))
+    # Level 2 (voxel 4) with patch 8 spans 32 voxels, so centres run [16, 48].
+    (size,) = _sizes([vol], resolutions=[[1, 1, 1], [2, 2, 2], [4, 4, 4]])
+    assert size == 40**3
+    assert size < 64**3
+
+
+def test_size_counts_the_level_actually_read(tmp_path):
+    """Size is measured on the pyramid level the finest scale reads, not always level 0."""
+    vol = _volume(tmp_path, "v", (64, 64, 64))
+    ds_fine = VolumeDataset(_config([vol], resolutions=[[1, 1, 1]]))
+    ds_coarse = VolumeDataset(_config([vol], resolutions=[[4, 4, 4]]))
+    assert ds_fine._volumes[0].scales.chosen_levels == [0]
+    assert ds_coarse._volumes[0].scales.chosen_levels == [2]
+    assert ds_fine._volumes[0].size == 64**3
+    assert ds_coarse._volumes[0].size == 16**3
+
+
+def test_size_is_invariant_to_voxel_size(tmp_path):
+    """Two volumes with identical content but different physical voxel size score equally.
+
+    Physical volume and patch count differ 1000x here; reachable stored voxels do not.
+    """
+    fine = _volume(tmp_path, "fine", (64, 64, 64), base_scale_factors=[1.0, 1.0, 1.0])
+    coarse = _volume(tmp_path, "coarse", (64, 64, 64), base_scale_factors=[10.0, 10.0, 10.0])
+    s_fine, = _sizes([fine], resolutions=[[1, 1, 1]])
+    s_coarse, = _sizes([coarse], resolutions=[[10, 10, 10]])
+    assert s_fine == s_coarse
+
+
+def test_size_is_equal_for_equal_reachable_content(tmp_path):
+    """A big volume read at a coarse level and a small volume at the same voxel size match."""
+    big = _volume(tmp_path, "big", (64, 64, 64))
+    small = _volume(tmp_path, "small", (16, 16, 16), num_scales=1,
+                    base_scale_factors=[4.0, 4.0, 4.0])
+    s_big, = _sizes([big], resolutions=[[4, 4, 4]])
+    s_small, = _sizes([small], resolutions=[[4, 4, 4]])
+    assert s_big == s_small == 16**3
+
+
+def test_size_does_not_depend_on_resolution_order(tmp_path):
+    """`resolutions` order only permutes the output l axis, so it must not change size."""
+    vol = _volume(tmp_path, "v", (64, 64, 64))
+    a, = _sizes([vol], resolutions=[[1, 1, 1], [1.5, 1.5, 1.5]])
+    b, = _sizes([vol], resolutions=[[1.5, 1.5, 1.5], [1, 1, 1]])
+    assert a == b
+
+
+def test_size_uses_the_finest_sampled_resolution(tmp_path):
+    """In sampling mode centres are bounded by the coarsest draw, but size is measured finest."""
+    vol = _volume(tmp_path, "v", (64, 64, 64))
+    size, = _sizes(
+        [vol],
+        resolutions=None,
+        resolution_sampling={"ranges": [[[1], [4]]], "n_scales": 1},
+    )
+    assert size == 40**3
+
+
+def test_size_positive_when_only_one_center_fits(tmp_path):
+    """A volume that admits exactly one centre still scores its window, never zero."""
+    vol = _volume(tmp_path, "v", (8, 8, 8), num_scales=1)
+    ds = VolumeDataset(_config([vol], resolutions=[[1, 1, 1]]))
+    vi = ds._volumes[0]
+    assert np.array_equal(vi.min_center, vi.max_center)
+    assert vi.size == 8**3
+
+
+def test_bounding_box_shrinks_size(tmp_path):
+    """bounding_box narrows the reachable region, and therefore size, for free."""
+    vol = _volume(tmp_path, "v", (64, 64, 64))
+    full, = _sizes([vol], resolutions=[[1, 1, 1]])
+    boxed, = _sizes([dict(vol, bounding_box=[[0, 48]] * 3)], resolutions=[[1, 1, 1]])
+    assert boxed < full
+
+
+# --- the exponent ----------------------------------------------------------
+
+
+def test_default_is_off_and_matches_manual_weights(tmp_path):
+    """size_weighting_exponent defaults to 0.0, reproducing the weight-only probabilities exactly."""
+    a = dict(_volume(tmp_path, "a", (64, 64, 64)), weight=0.75)
+    b = dict(_volume(tmp_path, "b", (16, 16, 16), num_scales=1), weight=0.25)
+    ds = VolumeDataset(_config([a, b]))
+    expected = np.array([0.75, 0.25])
+    np.testing.assert_array_equal(ds._probabilities, expected / expected.sum())
+
+
+def test_alpha_one_is_proportional_to_size(tmp_path):
+    a = _volume(tmp_path, "a", (64, 64, 64))
+    b = _volume(tmp_path, "b", (16, 16, 16), num_scales=1)
+    ds = VolumeDataset(_config([a, b], size_weighting_exponent=1.0))
+    sizes = np.array([v.size for v in ds._volumes])
+    np.testing.assert_allclose(ds._probabilities, sizes / sizes.sum())
+
+
+def test_composes_multiplicatively_with_weight(tmp_path):
+    """weight multiplies the size-derived prior rather than replacing it."""
+    a = _volume(tmp_path, "a", (64, 64, 64))
+    b = _volume(tmp_path, "b", (16, 16, 16), num_scales=1)
+    plain = VolumeDataset(_config([a, b], size_weighting_exponent=0.5))._probabilities
+    tilted = VolumeDataset(
+        _config([dict(a, weight=4.0), b], size_weighting_exponent=0.5)
+    )._probabilities
+    odds = lambda p: p[0] / p[1]  # noqa: E731
+    np.testing.assert_allclose(odds(tilted), 4.0 * odds(plain))
+
+
+def test_biases_actual_draws(tmp_path):
+    """The exponent changes which volume __getitem__ actually returns."""
+    big = _volume(tmp_path, "big", (64, 64, 64))
+    small = _volume(tmp_path, "small", (16, 16, 16), num_scales=1)
+    ds = VolumeDataset(_config([big, small], size_weighting_exponent=1.0))
+    np.random.seed(0)
+    drawn = [ds[i]["meta"]["volume"] for i in range(400)]
+    assert drawn.count("big") > 3 * drawn.count("small")
+
+
+def test_ignored_in_sequential(tmp_path):
+    """Sequential mode never reads _probabilities, so its grid is unchanged."""
+    a = _volume(tmp_path, "a", (64, 64, 64))
+    b = _volume(tmp_path, "b", (32, 32, 32))
+    kw = dict(sampling="sequential", resolutions=[[1, 1, 1]])
+    n0 = len(VolumeDataset(_config([a, b], size_weighting_exponent=0.0, **kw))._grid)
+    n1 = len(VolumeDataset(_config([a, b], size_weighting_exponent=1.0, **kw))._grid)
+    assert n0 == n1
+
+
+def test_negative_alpha_rejected(tmp_path):
+    vol = _volume(tmp_path, "v", (64, 64, 64))
+    with pytest.raises(ValueError, match="size_weighting_exponent must be >= 0"):
+        _config([vol], size_weighting_exponent=-0.1)


### PR DESCRIPTION
This PR implements a size-based volume sampling strategy. 

Currently, in `random` sampling mode each sample picks a volume first. By default that draw is uniform, which biases samples toward small volumes. The new `size_weighting_exponent` parameter modifies the random draw probabilities by how much data each volume actually holds as follows:

```yaml
size_weighting_exponent: 0.3   # p ∝ weight * size ** size_weighting_exponent
```

where `size` is the number of distinct stored voxels the sampler can reach, measured on the finest pyramid level any configured scale reads. This accounts for the patch window, `bounding_box`, and the pyramid level actually used, so a crop that admits only one patch center scores one patch window rather than its whole array. It is reported per volume in the dataset summary, alongside the resulting probability.

| `size_weighting_exponent` | effect |
| --- | --- |
| `0.0` (default) | size ignored; probabilities come from `weight` alone |
| `0.3` – `0.5` | tempered; sensible choice for a corpus spanning orders of magnitude |
| `1.0` | exactly proportional to reachable content; the largest volumes dominate |

The old per-volume `weight` parameter still applies and multiplies the size term, so per-volume overrides keep working. By default (`size_weighting_exponent=0.0`), the sampling probabilities are identical to weight-only sampling.