### PR TITLE
Warn on double-applied exp_factor + dead code cleanup

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -33,4 +33,3 @@ patch_size: [128, 128, 128]
 bbox_mode: "absolute" # "absolute" (world coords) or "relative" (relative to finest-level crop origin)
 samples_per_epoch: 1000
 cache_bytes: 1073741824
-isotropic: true

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -112,7 +112,6 @@
    ],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "from matplotlib.patches import Rectangle\n",
     "\n",
     "sample = dataset[0]\n",
     "img = sample[\"img\"]    # (L, C, X, Y, Z) for output_axes=\"lcxyz\"\n",

--- a/examples/example_2d.ipynb
+++ b/examples/example_2d.ipynb
@@ -28,7 +28,6 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import torch\n",
     "from torch.utils.data import ConcatDataset, DataLoader, default_collate\n",
     "\n",
     "from miao import MiaoConfig, VolumeDataset, load_config"

--- a/src/miao/dataset.py
+++ b/src/miao/dataset.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -480,6 +481,21 @@ class VolumeDataset(torch.utils.data.Dataset):
         # exp_factor converts the stored (microscope) voxel size to the effective (specimen) one.
         exp = vol_cfg.exp_factor
 
+        # exp_factor and a non-trivial outer (multiscale-level) OME-NGFF transform are two
+        # different ways of encoding the same expansion-factor correction. If a zarr's outer
+        # transform already carries it, applying exp_factor as well applies it twice.
+        if exp != 1.0 and (
+            any(s != 1.0 for s in image_meta.outer_scale)
+            or (label_meta is not None and any(s != 1.0 for s in label_meta.outer_scale))
+        ):
+            warnings.warn(
+                f"Volume {vol_cfg.name!r}: exp_factor={exp} is set in the config, but this "
+                "zarr's OME-NGFF metadata already has a non-trivial multiscale-level (outer) "
+                "coordinateTransformations scale. If that outer transform was written to store "
+                "the expansion factor, applying exp_factor as well will apply it twice.",
+                stacklevel=2,
+            )
+
         # Reference frame: finest pyramid level (index 0) absolute effective spatial voxel size.
         finest_spatial_factors = (
             np.array(image_meta.scales[0].scale_factors, dtype=np.float64)[img_sp_idx] / exp
@@ -564,7 +580,7 @@ class VolumeDataset(torch.utils.data.Dataset):
                 f"fit the volume at the requested {window} (patch_size={self.config.patch_size}, "
                 f"min_center={vol_info.min_center.tolist()} > "
                 f"max_center={vol_info.max_center.tolist()}). Use a finer max resolution, a "
-                f"smaller patch_size, or a larger volume."
+                f"smaller patch_size, or a larger volume. This also may happen if exp_factor and the OME-NGFF outer transform both encode the same expansion factor, effectively applying it twice."
             )
         return vol_info
 

--- a/src/miao/dataset.py
+++ b/src/miao/dataset.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -15,7 +15,6 @@ import torch.utils.data
 from miao.axes import (
     compute_permutation,
     map_patch_size_to_input,
-    reorient,
     spatial_axes,
     spatial_indices,
 )
@@ -838,7 +837,7 @@ class VolumeDataset(torch.utils.data.Dataset):
         """Build slices for image array: spatial dims get crop, channel gets slice(None)."""
         slices = []
         sp_i = 0
-        for dim_i, ax_char in enumerate(vol_info.img_axes):
+        for dim_i, _ax_char in enumerate(vol_info.img_axes):
             if dim_i in vol_info.img_spatial_idx:
                 slices.append(slice(int(origin[sp_i]), int(origin[sp_i] + read_shape[sp_i])))
                 sp_i += 1

--- a/src/miao/zarr_meta.py
+++ b/src/miao/zarr_meta.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 

--- a/src/miao/zarr_meta.py
+++ b/src/miao/zarr_meta.py
@@ -32,6 +32,7 @@ class OmeMetadata:
     axis_names: list[str]
     scales: dict[int, ScaleMetadata]  # level index -> metadata
     zarr_version: ZarrVersion
+    outer_scale: list[float]  # multiscale-level coordinateTransformations scale; identity if absent
 
 
 def detect_zarr_version(path: Path | str) -> ZarrVersion:
@@ -203,4 +204,5 @@ def read_ome_metadata(
         axis_names=axis_names,
         scales=scales,
         zarr_version=zarr_version,
+        outer_scale=outer_scale,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,27 +135,6 @@ def zarr2_volume(tmp_path: Path, request: pytest.FixtureRequest) -> Path:
 
 
 @pytest.fixture
-def zarr2_volume_xyz(tmp_path: Path) -> Path:
-    """Create a zarr2 OME-NGFF volume stored in xyz order."""
-    zarr_path = tmp_path / "test_volume_xyz.zarr"
-
-    _create_ome_ngff_zarr2(
-        zarr_path,
-        group_key="raw",
-        base_shape=(64, 64, 64),
-        num_scales=2,
-        axes=[
-            {"name": "x", "type": "space", "unit": "micrometer"},
-            {"name": "y", "type": "space", "unit": "micrometer"},
-            {"name": "z", "type": "space", "unit": "micrometer"},
-        ],
-        dtype="float32",
-    )
-
-    return zarr_path
-
-
-@pytest.fixture
 def zarr2_volume_anisotropic(tmp_path: Path) -> Path:
     """Create a zarr2 OME-NGFF volume with anisotropic voxel sizes.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@
 import pytest
 import yaml
 
-from miao.config import MiaoConfig, ResolutionSampling, VolumeConfig, load_config
+from miao.config import MiaoConfig, VolumeConfig, load_config
 
 
 def _vol(name="a", **kw):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,7 +1,6 @@
 """Tests for VolumeDataset."""
 
 from pathlib import Path
-from itertools import product as iproduct
 
 import numpy as np
 import pytest

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1123,6 +1123,29 @@ class TestExpFactor:
         bbox = sample["bbox"].numpy()  # (L, 2, 3)
         assert np.allclose(bbox[:, 1, :] - bbox[:, 0, :], [[8 * 0.5] * 3, [8 * 1.0] * 3])
 
+    def test_warns_when_outer_transform_also_present(self, tmp_path: Path):
+        """exp_factor + a non-trivial outer OME-NGFF transform on the same volume risks
+        applying the expansion factor twice."""
+        from conftest import _create_ome_ngff_zarr2
+
+        zarr_path = tmp_path / "outer_and_exp.zarr"
+        _create_ome_ngff_zarr2(
+            zarr_path,
+            group_key="raw",
+            base_shape=(64, 64, 64),
+            num_scales=3,
+            outer_scale=[0.25, 0.25, 0.25],
+        )
+        cfg = self._cfg(zarr_path, [[0.5, 0.5, 0.5]], exp_factor=4.0)
+        with pytest.warns(UserWarning, match="exp_factor"):
+            VolumeDataset(cfg)
+
+    def test_no_warning_without_outer_transform(self, zarr2_volume: Path, recwarn):
+        """The default fixture has no outer transform, so exp_factor alone should not warn."""
+        cfg = self._cfg(zarr2_volume, [[0.5, 0.5, 0.5]], exp_factor=4.0)
+        VolumeDataset(cfg)
+        assert len(recwarn) == 0
+
 
 class TestChunkAlignedSampling:
     """Tests for chunk_aligned=True random sampling."""


### PR DESCRIPTION
* Adds a UserWarning when a volume has both a config exp_factor and a non-trivial OME-NGFF outer (multiscale-level) transform set, since applying both could stack the expansion factor twice.
* Also removes a stale isotropic key from examples/config.yaml and cleans up unused imports/variables/fixtures found via a dead-code scan (ruff + vulture).